### PR TITLE
Quick checkpoint: per-room opt-out for auto-apply, and say so when a save was automatic

### DIFF
--- a/apps/web-server/scripts/persistent-room-maintenance-settings-smoke.ts
+++ b/apps/web-server/scripts/persistent-room-maintenance-settings-smoke.ts
@@ -18,9 +18,10 @@ function assert(condition: unknown, message: string): asserts condition {
 }
 
 try {
-	// Default: off, 20k budget, no file created by reading.
+	// Default: off, quick-checkpoint auto-apply on, 20k budget, no file created by reading.
 	const initial = readPersistentRoomMaintenanceSettings(agentId);
 	assert(initial.fastPathSecondApproval === false, "default fast-path must be off");
+	assert(initial.quickCheckpointAutoApply === true, "default quick-checkpoint auto-apply must be on");
 	assert(initial.memoryBudgetTokens === 20_000, "default memory budget must be 20k tokens");
 	assert(!fs.existsSync(persistentRoomMaintenanceSettingsPath(agentId)), "read must not create the settings file");
 
@@ -61,6 +62,20 @@ try {
 	writePersistentRoomMaintenanceSettings(agentId, { fastPathSecondApproval: false });
 	assert(readPersistentRoomMaintenanceSettings(agentId).fastPathSecondApproval === false, "toggle off should persist");
 
+	// Quick-checkpoint auto-apply: off round-trips, other writes preserve it,
+	// and settings files written before the field existed keep auto-apply on.
+	const quickOff = writePersistentRoomMaintenanceSettings(agentId, { quickCheckpointAutoApply: false });
+	assert(quickOff.quickCheckpointAutoApply === false, "quick auto-apply off should persist");
+	assert(quickOff.fastPathSecondApproval === false, "quick auto-apply write should preserve the fast-path toggle");
+	assert(readPersistentRoomMaintenanceSettings(agentId).quickCheckpointAutoApply === false, "reread should see quick auto-apply off");
+	assert(writePersistentRoomMaintenanceSettings(agentId, { memoryBudgetTokens: 25_000 }).quickCheckpointAutoApply === false, "budget-only write should preserve quick auto-apply");
+	writePersistentRoomMaintenanceSettings(agentId, { quickCheckpointAutoApply: true });
+	assert(readPersistentRoomMaintenanceSettings(agentId).quickCheckpointAutoApply === true, "quick auto-apply back on should persist");
+	const legacy = JSON.parse(fs.readFileSync(persistentRoomMaintenanceSettingsPath(agentId), "utf-8"));
+	delete legacy.quickCheckpointAutoApply;
+	fs.writeFileSync(persistentRoomMaintenanceSettingsPath(agentId), JSON.stringify(legacy, null, 2) + "\n", "utf-8");
+	assert(readPersistentRoomMaintenanceSettings(agentId).quickCheckpointAutoApply === true, "legacy settings without the field should keep auto-apply on");
+
 	// Validation.
 	let threw = false;
 	try {
@@ -69,6 +84,13 @@ try {
 		threw = /must be a boolean/.test((error as Error).message);
 	}
 	assert(threw, "non-boolean input should be rejected");
+	let quickThrew = false;
+	try {
+		writePersistentRoomMaintenanceSettings(agentId, { quickCheckpointAutoApply: "yes" as unknown as boolean });
+	} catch (error) {
+		quickThrew = /quickCheckpointAutoApply must be a boolean/.test((error as Error).message);
+	}
+	assert(quickThrew, "non-boolean quick auto-apply should be rejected");
 	let threwId = false;
 	try {
 		readPersistentRoomMaintenanceSettings("../escape");
@@ -80,6 +102,7 @@ try {
 	// Corrupt file falls back to defaults.
 	fs.writeFileSync(persistentRoomMaintenanceSettingsPath(agentId), "not json", "utf-8");
 	assert(readPersistentRoomMaintenanceSettings(agentId).fastPathSecondApproval === false, "corrupt settings should fall back to default off");
+	assert(readPersistentRoomMaintenanceSettings(agentId).quickCheckpointAutoApply === true, "corrupt settings should fall back to auto-apply on");
 
 	fs.rmSync(root, { recursive: true, force: true });
 	console.log("persistent-room maintenance settings smoke passed");

--- a/apps/web-server/src/index.ts
+++ b/apps/web-server/src/index.ts
@@ -1162,7 +1162,7 @@ app.put("/api/persistent-agents/:id/maintenance-settings", async (req, reply) =>
 	try {
 		const status = getUsablePersistentAgentStatusForNormalUse(idRaw);
 		const body = (req.body ?? {}) as any;
-		const settings = writePersistentRoomMaintenanceSettings(status.id, { fastPathSecondApproval: body.fastPathSecondApproval, memoryBudgetTokens: body.memoryBudgetTokens });
+		const settings = writePersistentRoomMaintenanceSettings(status.id, { fastPathSecondApproval: body.fastPathSecondApproval, quickCheckpointAutoApply: body.quickCheckpointAutoApply, memoryBudgetTokens: body.memoryBudgetTokens });
 		return { agentId: status.id, settings };
 	} catch (e) {
 		return persistentAgentNormalUseErrorReply(reply, e);

--- a/apps/web-server/src/persistent-room-maintenance-settings.ts
+++ b/apps/web-server/src/persistent-room-maintenance-settings.ts
@@ -12,6 +12,13 @@ import { DEFAULT_PERSISTENT_ROOM_AGENTS_ROOT, persistentAgentRootPath } from "./
  * and the server-side propose/approve split is unchanged — this file only
  * stores the preference.
  *
+ * `quickCheckpointAutoApply` governs the default Checkpoint button: when true
+ * (the default, matching historical behaviour) a blocker-free proposal is
+ * approved immediately without showing the preview; when false the quick
+ * button still generates the proposal but always falls back to the manual
+ * preview for approval. Proposals with blockers fall back to the preview
+ * either way, and the server-side propose/approve split is unchanged.
+ *
  * `memoryBudgetTokens` is the room's advisory memory budget: the size the
  * whole L1b should stay near. It never gates anything — it drives the
  * settings meter, the room-card nudge, and a target line in the absorb /
@@ -21,6 +28,7 @@ import { DEFAULT_PERSISTENT_ROOM_AGENTS_ROOT, persistentAgentRootPath } from "./
 export interface PersistentRoomMaintenanceSettings {
 	schemaVersion: 1;
 	fastPathSecondApproval: boolean;
+	quickCheckpointAutoApply: boolean;
 	memoryBudgetTokens: number;
 	updatedAt: string;
 }
@@ -41,6 +49,7 @@ function clampMemoryBudgetTokens(value: unknown): number {
 const DEFAULT_SETTINGS: PersistentRoomMaintenanceSettings = {
 	schemaVersion: 1,
 	fastPathSecondApproval: false,
+	quickCheckpointAutoApply: true,
 	memoryBudgetTokens: MEMORY_BUDGET_DEFAULT_TOKENS,
 	updatedAt: "",
 };
@@ -65,6 +74,9 @@ export function readPersistentRoomMaintenanceSettings(agentIdRaw: string, option
 		return {
 			schemaVersion: 1,
 			fastPathSecondApproval: raw.fastPathSecondApproval === true,
+			// Settings files written before this field existed must keep the
+			// historical auto-apply behaviour, so only an explicit false disables.
+			quickCheckpointAutoApply: raw.quickCheckpointAutoApply !== false,
 			memoryBudgetTokens: clampMemoryBudgetTokens(raw.memoryBudgetTokens),
 			updatedAt: typeof raw.updatedAt === "string" ? raw.updatedAt : "",
 		};
@@ -73,14 +85,16 @@ export function readPersistentRoomMaintenanceSettings(agentIdRaw: string, option
 	}
 }
 
-export function writePersistentRoomMaintenanceSettings(agentIdRaw: string, input: { fastPathSecondApproval?: unknown; memoryBudgetTokens?: unknown }, options: PersistentRoomMaintenanceSettingsStorageOptions = {}, now = new Date()): PersistentRoomMaintenanceSettings {
+export function writePersistentRoomMaintenanceSettings(agentIdRaw: string, input: { fastPathSecondApproval?: unknown; quickCheckpointAutoApply?: unknown; memoryBudgetTokens?: unknown }, options: PersistentRoomMaintenanceSettingsStorageOptions = {}, now = new Date()): PersistentRoomMaintenanceSettings {
 	if (input?.fastPathSecondApproval !== undefined && typeof input.fastPathSecondApproval !== "boolean") throw new Error("fastPathSecondApproval must be a boolean");
+	if (input?.quickCheckpointAutoApply !== undefined && typeof input.quickCheckpointAutoApply !== "boolean") throw new Error("quickCheckpointAutoApply must be a boolean");
 	if (input?.memoryBudgetTokens !== undefined && (typeof input.memoryBudgetTokens !== "number" || !Number.isFinite(input.memoryBudgetTokens))) throw new Error("memoryBudgetTokens must be a number");
 	const current = readPersistentRoomMaintenanceSettings(agentIdRaw, options);
 	const settingsPath = persistentRoomMaintenanceSettingsPath(agentIdRaw, options);
 	const settings: PersistentRoomMaintenanceSettings = {
 		schemaVersion: 1,
 		fastPathSecondApproval: input?.fastPathSecondApproval !== undefined ? input.fastPathSecondApproval as boolean : current.fastPathSecondApproval,
+		quickCheckpointAutoApply: input?.quickCheckpointAutoApply !== undefined ? input.quickCheckpointAutoApply as boolean : current.quickCheckpointAutoApply,
 		memoryBudgetTokens: input?.memoryBudgetTokens !== undefined ? clampMemoryBudgetTokens(input.memoryBudgetTokens) : current.memoryBudgetTokens,
 		updatedAt: now.toISOString(),
 	};

--- a/apps/web-ui/src/App.tsx
+++ b/apps/web-ui/src/App.tsx
@@ -3246,6 +3246,10 @@ export function App() {
 			setCheckpointQuickBlockedReasons(blockers);
 			return;
 		}
+		if (!(await roomQuickCheckpointAutoApplyEnabled(targetChat.agentId))) {
+			setCheckpointQuickBlockedReasons(["automatic apply is turned off for this room"]);
+			return;
+		}
 		setCheckpointApprovalLoading(true);
 		try {
 			const approvedRecentContext = buildApprovedRecentContextMarkdown(proposal, {
@@ -3257,7 +3261,7 @@ export function App() {
 			await bindToApprovedCheckpointRuntime(approval, targetChat);
 			void refreshPersistentAgentStatus();
 			resetCheckpointInput();
-			const savedNote = approval.warnings.length > 0 ? `Checkpoint saved to memory. ${approval.warnings.join(" ")}` : "Checkpoint saved to memory.";
+			const savedNote = approval.warnings.length > 0 ? `Checkpoint saved to memory automatically. ${approval.warnings.join(" ")}` : "Checkpoint saved to memory automatically.";
 			setItems((s) => [...s, { kind: "system", id: nid(), text: savedNote }]);
 		} catch (e) {
 			setCheckpointApprovalError(`The checkpoint could not save automatically. Review and approve it manually. ${(e as Error).message}`);
@@ -3802,6 +3806,16 @@ export function App() {
 		try {
 			return (await fetchPersistentRoomMaintenanceSettings(agentId)).settings.fastPathSecondApproval === true;
 		} catch {
+			return false;
+		}
+	}
+
+	async function roomQuickCheckpointAutoApplyEnabled(agentId: PersistentAgentId): Promise<boolean> {
+		try {
+			return (await fetchPersistentRoomMaintenanceSettings(agentId)).settings.quickCheckpointAutoApply !== false;
+		} catch {
+			// When the preference cannot be read, fall back to manual review —
+			// the safe direction is showing the proposal, not silently applying it.
 			return false;
 		}
 	}

--- a/apps/web-ui/src/components/RoomMaintenanceSection.tsx
+++ b/apps/web-ui/src/components/RoomMaintenanceSection.tsx
@@ -14,6 +14,7 @@ function fmtTokensK(value: number): string {
 
 export function RoomMaintenanceSection({ status }: { status: PersistentAgentStatus }) {
 	const [fastPath, setFastPath] = useState<boolean | null>(null);
+	const [quickAutoApply, setQuickAutoApply] = useState<boolean | null>(null);
 	const [budget, setBudget] = useState<number | null>(null);
 	const [savedBudget, setSavedBudget] = useState<number | null>(null);
 	const [saving, setSaving] = useState(false);
@@ -23,6 +24,7 @@ export function RoomMaintenanceSection({ status }: { status: PersistentAgentStat
 	useEffect(() => {
 		let cancelled = false;
 		setFastPath(null);
+		setQuickAutoApply(null);
 		setBudget(null);
 		setSavedBudget(null);
 		setError(null);
@@ -30,6 +32,7 @@ export function RoomMaintenanceSection({ status }: { status: PersistentAgentStat
 			.then((response) => {
 				if (cancelled) return;
 				setFastPath(response.settings.fastPathSecondApproval);
+				setQuickAutoApply(response.settings.quickCheckpointAutoApply);
 				setBudget(response.settings.memoryBudgetTokens);
 				setSavedBudget(response.settings.memoryBudgetTokens);
 			})
@@ -78,6 +81,23 @@ export function RoomMaintenanceSection({ status }: { status: PersistentAgentStat
 		}
 	}
 
+	async function toggleQuickAutoApply(next: boolean) {
+		if (saving || quickAutoApply === null) return;
+		setSaving(true);
+		setError(null);
+		const previous = quickAutoApply;
+		setQuickAutoApply(next);
+		try {
+			const response = await updatePersistentRoomMaintenanceSettings(status.id, { quickCheckpointAutoApply: next });
+			setQuickAutoApply(response.settings.quickCheckpointAutoApply);
+		} catch (e) {
+			setQuickAutoApply(previous);
+			setError((e as Error).message);
+		} finally {
+			setSaving(false);
+		}
+	}
+
 	const currentMemoryTokens = status.promptBudget?.l1bEstimatedTokens ?? null;
 	const usagePercent = budget !== null && currentMemoryTokens !== null ? Math.round((currentMemoryTokens / budget) * 100) : null;
 	const overBudget = usagePercent !== null && usagePercent > 100;
@@ -103,6 +123,29 @@ export function RoomMaintenanceSection({ status }: { status: PersistentAgentStat
 					applied without the second review screen. Proposals that touch must-keep memory
 					or fail validation always come back for manual review, and the worker's notes are
 					shown after applying. Every change still archives the previous memory and writes
+					an audit record.
+				</p>
+			</details>
+			<label className="workspaces-tool-row">
+				<span>Quick checkpoint applies automatically</span>
+				<input
+					className="workspaces-tool-switch"
+					type="checkbox"
+					checked={quickAutoApply === true}
+					disabled={quickAutoApply === null || saving}
+					onChange={(e) => void toggleQuickAutoApply(e.target.checked)}
+					aria-label="Quick checkpoint applies automatically"
+				/>
+			</label>
+			<p className="room-maintenance-hint">Save blocker-free Checkpoint proposals without showing the preview.</p>
+			<details className="room-settings-details">
+				<summary>How it works</summary>
+				<p>
+					The Checkpoint button drafts a memory proposal and, when nothing deterministic
+					blocks it, saves it without showing you the content first. Turn this off to
+					always review the proposed entry before it becomes memory. Proposals with
+					blockers — trimmed transcripts or incomplete drafts — always come back for
+					review either way, and every save still archives the previous memory and writes
 					an audit record.
 				</p>
 			</details>

--- a/apps/web-ui/src/persistent-room-management-api.ts
+++ b/apps/web-ui/src/persistent-room-management-api.ts
@@ -55,6 +55,7 @@ export function renamePersistentRoom(agentId: PersistentAgentId, displayName: st
 export interface PersistentRoomMaintenanceSettings {
 	schemaVersion: 1;
 	fastPathSecondApproval: boolean;
+	quickCheckpointAutoApply: boolean;
 	memoryBudgetTokens: number;
 	updatedAt: string;
 }
@@ -72,7 +73,7 @@ export function fetchPersistentRoomMaintenanceSettings(agentId: PersistentAgentI
 	);
 }
 
-export function updatePersistentRoomMaintenanceSettings(agentId: PersistentAgentId, update: { fastPathSecondApproval?: boolean; memoryBudgetTokens?: number }): Promise<PersistentRoomMaintenanceSettingsResponse> {
+export function updatePersistentRoomMaintenanceSettings(agentId: PersistentAgentId, update: { fastPathSecondApproval?: boolean; quickCheckpointAutoApply?: boolean; memoryBudgetTokens?: number }): Promise<PersistentRoomMaintenanceSettingsResponse> {
 	return fetchJson<PersistentRoomMaintenanceSettingsResponse>(
 		`/api/persistent-agents/${encodeURIComponent(agentId)}/maintenance-settings`,
 		{


### PR DESCRIPTION
## Summary

The default Checkpoint button (as opposed to "Checkpoint with options…") drafts a compression proposal and, when nothing deterministic blocks it (no elision, no parse failure, no missing field), approves and saves it immediately without showing the content. That's a deliberate, useful convenience — but for a product whose core promise is "every memory write approved by you," some rooms may want the one-click button to still stop for a human look, and there was no way to keep the quick button while adding that review step back in.

This PR adds a room-level opt-out, following the exact pattern already established by `fastPathSecondApproval` for the absorb/review flows:

- **New setting `quickCheckpointAutoApply`** in room maintenance settings (default `true` — existing behavior is unchanged unless a room explicitly opts out; settings files written before this field existed are read as `true`, so no migration is needed).
- **When off**, the quick Checkpoint button still generates the proposal, but always falls back to the existing manual preview screen instead of auto-approving — reusing the existing fast-path-blocked note pattern ("Not saved automatically. This proposal needs your review because …") so the reason is visible.
- **When auto-apply does run** (the default), the saved system message now says "Checkpoint saved to memory **automatically**." instead of just "Checkpoint saved to memory.", matching the existing disclosure language used by the absorb fast path ("Applied automatically…").
- If the room's maintenance settings can't be read for any reason, the flow now falls back to manual review rather than applying silently — the safe direction is showing the proposal, not applying it.
- A second toggle in the Room Settings → Memory maintenance section, with its own "How it works" explainer, mirroring the existing "Automatic memory maintenance" toggle's UI.

Nothing about the propose/approve server split, the checkpoint approval transaction, staleness checks, or archiving changes — this only adds a UI/preference gate in front of the existing quick-apply behavior.

## Why

While auditing the checkpoint approval path, I found that `quickCheckpointBlockers` (the gate in front of auto-apply) only checks for deterministic problems — transcript elision, parse failures, missing fields — not content fidelity against the transcript. That's a reasonable scope for an automatic gate (content fidelity isn't mechanically checkable), but it means the quick button can save a fluent, well-formed, entirely fabricated summary without any human ever seeing it, and content marked **must-keep** is protected from later pruning by Learn/Review Memory. This isn't a bug in the gate — the gate does exactly what it's documented to do — but rooms that want a human in the loop for every write had no way to get that from the one-click flow. This PR gives them one, opt-in, without touching the default.

## Test plan

- [x] `npm run build` — clean
- [x] `npx tsc --noEmit -p apps/web-ui/tsconfig.json` — clean
- [x] `npm run smokes` — 56/56 passing (full suite, CI parity)
- [x] `persistent-room-maintenance-settings-smoke.ts` extended: default-on, round-trip, merge-preservation across other settings writes, legacy-settings-file migration (field absent → reads as `true`), and boolean validation for the new field
- [x] Manual verification in `./scripts/exxperts-web` against a live Claude Pro/Max profile:
  - Toggle on (default): quick Checkpoint drafted and saved automatically; system note read "Checkpoint saved to memory automatically."
  - Toggle off: quick Checkpoint drafted the same proposal but stopped at the manual review screen with "Not saved automatically. This proposal needs your review because automatic apply is turned off for this room."; proposal was reviewable and was discarded (not applied) to leave the test room's memory untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)