### PR TITLE
Room Settings wheel  inside the room view

### DIFF
--- a/apps/web-ui/src/App.tsx
+++ b/apps/web-ui/src/App.tsx
@@ -2546,14 +2546,19 @@ export function App() {
 	const preview = rightPane?.kind === "preview" ? rightPane.data : null;
 	const setPreview = (data: ApprovalPreviewData | null) => setRightPane(data ? { kind: "preview", data } : null);
 
+	// The room settings wheel in the topbar opens the same modal the launcher
+	// card's wheel opens. Declared here because the Escape handler below has to
+	// yield to it.
+	const [roomSettingsOpen, setRoomSettingsOpen] = useState(false);
+
 	// Escape closes the artifact/run pane, the keyboard twin of clicking its X
 	// or the selected rail row. A maximized pane restores first (one Escape per
 	// step), and any open dialog above the pane (delete confirm, export
-	// collision, file-delete confirm, Save-as prompt) owns Escape until
-	// dismissed — one Escape, one layer.
+	// collision, file-delete confirm, Save-as prompt, room settings) owns Escape
+	// until dismissed — one Escape, one layer.
 	useEffect(() => {
 		const paneOpen = rightPane?.kind === "artifactViewer" || rightPane?.kind === "taskRun";
-		if (!paneOpen || assetDeleteConfirm || exportCollision || fileDeleteConfirm || saveAsPrompt) return;
+		if (!paneOpen || assetDeleteConfirm || exportCollision || fileDeleteConfirm || saveAsPrompt || roomSettingsOpen) return;
 		function onKeyDown(event: KeyboardEvent) {
 			if (event.key !== "Escape") return;
 			if (artifactMaximized) setArtifactMaximized(false);
@@ -2561,7 +2566,7 @@ export function App() {
 		}
 		document.addEventListener("keydown", onKeyDown);
 		return () => document.removeEventListener("keydown", onKeyDown);
-	}, [rightPane, artifactMaximized, assetDeleteConfirm, exportCollision, fileDeleteConfirm, saveAsPrompt]);
+	}, [rightPane, artifactMaximized, assetDeleteConfirm, exportCollision, fileDeleteConfirm, saveAsPrompt, roomSettingsOpen]);
 	const [conversationId, setConversationId] = useState<string>(() => newConversationId());
 	const [authStatus, setAuthStatus] = useState<AuthStatusResponse | null>(null);
 	const [modelStatus, setModelStatus] = useState<WebChatModelStatus | null>(null);
@@ -2843,6 +2848,10 @@ export function App() {
 			void refreshRoomFiles();
 		}
 	}, [persistentChat, refreshAssetRows, refreshRoomFiles]);
+	// Leaving the room (or having it deleted underneath us) closes the wheel.
+	useEffect(() => {
+		if (!persistentChat) setRoomSettingsOpen(false);
+	}, [persistentChat]);
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
 	const attachFileInputRef = useRef<HTMLInputElement>(null);
 	const workbenchRef = useRef<HTMLDivElement>(null);
@@ -5863,7 +5872,18 @@ export function App() {
 		setView("home");
 	}
 
-	const activeDisplay = persistentChat?.displayName ?? "";
+	// The room's own record wins over the name the thread was opened with, so a
+	// rename from the in-room settings wheel lands on the header and the
+	// composer placeholder right away. (persistentChat itself is left alone —
+	// changing it re-binds the room websocket.)
+	const activeDisplay = (persistentChat ? currentPersistentStatus?.displayName : "") || persistentChat?.displayName || "";
+	// The modal tracks the LIVE status for this room the same way the launcher's
+	// does — it renders off persistentAgentStatuses, and opening refetches so it
+	// starts from what the server says right now.
+	function openRoomSettings(): void {
+		setRoomSettingsOpen(true);
+		void refreshPersistentAgentStatus();
+	}
 	const absorbWorkflowOpen = absorbWorkflow.step !== "closed";
 	const structuralReviewWorkflowOpen = structuralReviewWorkflow.step !== "closed";
 	const standbyLockedModels = persistentAgentStatuses
@@ -6061,6 +6081,11 @@ export function App() {
 			usage={usage}
 			contextHealth={persistentChat ? contextHealth : null}
 			currentModelLabel={currentModelLabel}
+			topbarActions={
+				persistentChat && currentPersistentStatus?.exists
+					? <button className="card-gear-btn" aria-label="Room settings" title="Room settings" onClick={openRoomSettings}>⚙</button>
+					: undefined
+			}
 			composerRightActions={
 				persistentChat ? (
 					<>
@@ -6164,6 +6189,9 @@ export function App() {
 			checkpointPreviewSlot={checkpointPreviewOpen && persistentChat && <CheckpointPreviewShell chat={persistentChat} itemCount={items.length} rememberText={checkpointRememberText} density={checkpointDensity} proposal={checkpointProposal} loading={checkpointProposalLoading} error={checkpointProposalError} approvalLoading={checkpointApprovalLoading} approvalError={checkpointApprovalError} approvalResult={checkpointApprovalResult} quickRequested={checkpointQuickRequested} quickBlockedReasons={checkpointQuickBlockedReasons} consultRunning={consultState.phase === "streaming"} taskRunning={taskState.phase === "running"} pendingConsultHandoffCount={pendingHandoffs.filter((block) => !isSpecialistHandoffBlock(block)).length} pendingTaskHandoffCount={pendingHandoffs.filter(isSpecialistHandoffBlock).length} onRememberTextChange={(text) => { setCheckpointRememberText(text); setCheckpointProposal(null); setCheckpointProposalError(null); setCheckpointApprovalError(null); setCheckpointApprovalResult(null); }} onDensityChange={(next) => { setCheckpointDensity(next); setCheckpointProposal(null); setCheckpointProposalError(null); setCheckpointApprovalError(null); setCheckpointApprovalResult(null); }} onGenerate={generateCheckpointProposal} onApprove={approveCheckpointProposal} onDiscard={() => { setCheckpointProposal(null); setCheckpointProposalError(null); setCheckpointApprovalError(null); setCheckpointApprovalResult(null); setCheckpointQuickRequested(false); setCheckpointQuickBlockedReasons(null); setCheckpointPreviewOpen(false); }} onContinueAfterCheckpoint={continueAfterCheckpoint} onRestAfterCheckpoint={restAfterCheckpoint} onClose={() => setCheckpointPreviewOpen(false)} />}
 			globalOverlaySlot={
 				<>
+					{roomSettingsOpen && currentPersistentStatus && (
+						<RoomSettingsModal status={currentPersistentStatus} onClose={() => setRoomSettingsOpen(false)} onArchive={archivePersistentAgentRoom} onRefresh={refreshPersistentAgentStatus} />
+					)}
 					{helpOpen && <Help onClose={() => setHelpOpen(false)} />}
 					{assetDeleteConfirm && <AssetDeleteDialog title={assetDeleteConfirm.title} onDelete={() => { const row = assetDeleteConfirm; setAssetDeleteConfirm(null); if (row) void deleteAssetRow(row); }} onCancel={() => setAssetDeleteConfirm(null)} />}
 					{fileDeleteConfirm && <FileDeleteDialog fileName={fileDeleteConfirm.fileName} reason={fileDeleteConfirm.reason} onDelete={() => { const confirm = fileDeleteConfirm; setFileDeleteConfirm(null); if (confirm) void performFileDelete(confirm.fileName); }} onCancel={() => setFileDeleteConfirm(null)} />}


### PR DESCRIPTION
Hi, I started testing exxperts yesterday and I think its GREAT!  wanted to add a tiny feature, maybe have a look if you like the addition) ❤️ 

Explanation:

The Room view now carries the same ⚙ the launcher card has and it opens the very same room settings modal, rendered off the live room status so the open modal follows a refresh instead of a snapshot, Escape yields to it so one press still closes exactly one layer, and the room header and composer placeholder read the room's own name so a rename from the wheel lands without re-binding the room websocket

What had to be accomplished

The ⚙ on the launcher card was the only way into room settings: from inside a room you had to leave and come back. The same wheel, opening the same settings surface, had to work from inside the room too.

How it was achieved

Nothing new had to be invented, only connected. The chat shell already exposed an unused topbarActions slot and a globalOverlaySlot (components/in-room-chat.tsx), and App already derived currentPersistentStatus for the room it has open. So the topbar renders the same ⚙ button the card renders — same class, same label, same title — and the same RoomSettingsModal goes into the overlay slot with the same archive and refresh wiring the Landing screen passes it. One component, two entry points; no props added to the shell view.

Three details the in-room context forced:

- The modal renders off currentPersistentStatus, the live entry in persistentAgentStatuses, rather than a status captured when it opened, and opening refetches. A snapshot could carry stale mid-stream inFlight flags forever — the same reason the launcher's modal tracks its room by id instead of holding the object.
- The artifact/run pane's Escape handler now stands down while the wheel is open, so the one-Escape-one-layer rule still holds, the way the delete-confirm and export-collision dialogs already claim Escape.
- activeDisplay prefers the room record's name over the name the thread was opened with, so renaming from inside the room updates the header and the "Ask …" placeholder immediately. persistentChat is deliberately left alone: it is a dependency of the websocket effect, so writing the new name into it would tear down and re-bind the room socket and take the stream, consult and task view state with it.

Leaving the room, or deleting it from the modal's danger zone, closes the wheel. Verified with tsc --noEmit and a clean vite build; the in-room wheel was then confirmed by hand in the running app.