### PR TITLE
install: the Windows installer survives a detached HEAD again: the up…

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -169,11 +169,30 @@ function Test-DiskSpace([string]$Dir) {
     }
 }
 
+# Runs git purely for its exit code, immune to the two ways PowerShell turns an
+# ordinary native-command failure into a TERMINATING error under
+# $ErrorActionPreference = "Stop":
+#   - stderr that is redirected (anywhere, including $null) comes back as a
+#     NativeCommandError record instead of plain text, and
+#   - PowerShell 7.3+ rethrows a non-zero exit code when
+#     $PSNativeCommandUseErrorActionPreference is enabled.
+# Both assignments below are function-scoped: they shadow the script values for
+# this call only and vanish when it returns. On Windows PowerShell 5.1 the
+# second name simply does not exist, and assigning it is harmless.
+# Without this, probing a detached HEAD for an upstream branch killed the
+# installer on the very line meant to tolerate it (git says "fatal: HEAD does
+# not point to a branch" on stderr) — which is exactly what a CI checkout is.
+function Test-GitSucceeds([string[]]$GitArgs) {
+    $ErrorActionPreference = "Continue"
+    $PSNativeCommandUseErrorActionPreference = $false
+    & git @GitArgs 2>&1 | Out-Null
+    return $LASTEXITCODE -eq 0
+}
+
 # Bring an existing clone up to date. Skips quietly when the clone has no
 # upstream branch to pull from (e.g. a CI checkout on a detached commit).
 function Update-Clone([string]$Dir) {
-    & git -C $Dir rev-parse --abbrev-ref --symbolic-full-name "@{u}" *> $null
-    if ($LASTEXITCODE -ne 0) {
+    if (-not (Test-GitSucceeds @("-C", $Dir, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"))) {
         Say "no upstream branch configured in $Dir; skipping the update pull."
         return
     }


### PR DESCRIPTION
…stream-branch probe was being killed by its own error message, because redirecting a native command's stderr while ErrorActionPreference is Stop turns git's "fatal: HEAD does not point to a branch" into a terminating NativeCommandError — so the check written specifically to tolerate a CI checkout was the thing failing the install

What had to be accomplished

Every "Install Windows" CI job died on install.ps1 line 175. CI checks out a detached commit, which is exactly the case Update-Clone already meant to skip over quietly.

How it was achieved

The probe itself was right; PowerShell was the problem. A native command's stderr becomes an ErrorRecord instead of plain text as soon as that stream is redirected anywhere — including `*> $null` — and under $ErrorActionPreference = "Stop" (set at the top of this script) that record terminates the run. git writes "fatal: HEAD does not point to a branch" to stderr and exits 128 on a detached HEAD, so the script died before ever reaching the $LASTEXITCODE test one line below that handles precisely that. install.sh does the same probe and is fine: in bash, redirecting stderr carries no such meaning.

So the redirect moves into a Test-GitSucceeds helper that runs git purely for its exit code and neutralises both PowerShell traps for the duration of the call: $ErrorActionPreference = "Continue" so redirected stderr stays non-terminating, and $PSNativeCommandUseErrorActionPreference = $false so PowerShell 7.3+ does not rethrow the non-zero exit either. Both assignments are function-scoped, so they shadow the script's values for that one call and vanish on return; on Windows PowerShell 5.1 the second name does not exist and assigning it is harmless.

Behaviour is unchanged where it already worked — verified against the three states the probe can meet: a tracking branch exits 0 and still pulls, while a detached HEAD and a branch with no upstream both exit 128 and now skip with the message the function always intended to print.