### PR TITLE
settings: AI setup becomes Settings, with AI provider and Web search as peer sections

### DIFF
--- a/apps/web-ui/src/App.tsx
+++ b/apps/web-ui/src/App.tsx
@@ -751,6 +751,8 @@ function AiProfileSwitcherSection({ status, onSelect, onRefresh, onRefreshAuth }
 	);
 	return (
 		<section className="ai-setup-section ai-profile-switcher-section" aria-label="AI profile selection">
+			<div className="ai-setup-section-heading"><h2>AI provider</h2></div>
+			<p className="ai-setup-copy">Sign in and choose the profile your exxperts run on. A profile is a provider plus the models you've approved for Rooms, Memorize, and Review.</p>
 			{status ? (
 				status.profiles.length > 0 ? (
 					<div className="ai-profile-card">
@@ -1220,8 +1222,7 @@ function AiSetupShell({ onHome, onDashboard, onConnectors, onMemory, onSkills, o
 			<ProductSidebar onHome={onHome} onAiSetup={() => {}} onDashboard={onDashboard} onConnectors={onConnectors} onMemory={onMemory} onSkills={onSkills} theme={theme} onToggleTheme={onToggleTheme} active="ai-setup" />
 			<div className="landing ai-setup-page">
 				<section className="landing-hero ai-setup-hero">
-					<h1>AI setup.</h1>
-					<p>Sign in and choose the profile your exxperts run on. A profile is a provider plus the models you've approved for Rooms, Memorize, and Review.</p>
+					<h1>Settings.</h1>
 				</section>
 				<AiProfileSwitcherSection status={aiProfileStatus} onSelect={onSelectAiProfile} onRefresh={onRefreshAiProfile} onRefreshAuth={onRefreshAuth} />
 				{/* Below the profiles, because it is the smaller decision and it is
@@ -2393,7 +2394,7 @@ function absorbUnavailableCopy(availability: AbsorbAvailability): { heading: str
 	}
 	return {
 		heading: "Memorizing cannot start yet",
-		body: "Memorizing cannot run for this room right now. No memory was changed. If this persists, check the room's AI profile in AI setup.",
+		body: "Memorizing cannot run for this room right now. No memory was changed. If this persists, check the room's AI profile in Settings.",
 		detail: availability.message || availability.error || null,
 	};
 }
@@ -4850,7 +4851,7 @@ export function App() {
 					kind: "system",
 					id: errorLineId,
 					level: "error",
-					text: `The model could not respond${detail ? ` · ${detail}` : ""} · check the model and its sign-in in AI setup.`,
+					text: `The model could not respond${detail ? ` · ${detail}` : ""} · check the model and its sign-in in Settings.`,
 				}]);
 			}
 			dispatchStream({ type: "message_end", finalText: extractAssistantText(ev.message), stopReason: ev.message.stopReason, now });

--- a/apps/web-ui/src/components/Help.tsx
+++ b/apps/web-ui/src/components/Help.tsx
@@ -38,7 +38,7 @@ export function Help({ onClose }: Props) {
 					<section>
 						<h3>Your AI</h3>
 						<p>
-							Connect the AI you already have in AI setup: sign in with a subscription, paste
+							Connect the AI you already have in Settings: sign in with a subscription, paste
 							an API key, or point at a company gateway. You approve which models rooms may
 							use, and you switch between AI profiles right here in the settings menu.
 						</p>

--- a/apps/web-ui/src/components/RoomsGuide.tsx
+++ b/apps/web-ui/src/components/RoomsGuide.tsx
@@ -7,7 +7,7 @@ interface Props {
 const POINTS: { term: string; body: string }[] = [
 	{
 		term: "Bring your own AI",
-		body: "exxperts runs with the AI you already have. Connect a subscription or an API key once, in AI setup behind the gear at the bottom of the sidebar.",
+		body: "exxperts runs with the AI you already have. Connect a subscription or an API key once, in Settings behind the gear at the bottom of the sidebar.",
 	},
 	{
 		term: "Create and chat",

--- a/apps/web-ui/src/components/launcher-room-card.tsx
+++ b/apps/web-ui/src/components/launcher-room-card.tsx
@@ -160,8 +160,8 @@ export function PersistentAgentCard({ status, modelStatus, aiProfileStatus, thre
 	const standbyActionTitle = standbyModelAllowed
 		? "Resume this standby thread"
 		: switchTargetProfile
-			? `This thread is locked to ${lockedModelLabel}. Switch the AI profile to ${switchTargetProfile.label} in AI setup to resume it.`
-			: `This thread is locked to ${lockedModelLabel}, which no ready AI profile provides right now. Open AI setup to connect one.`;
+			? `This thread is locked to ${lockedModelLabel}. Switch the AI profile to ${switchTargetProfile.label} in Settings to resume it.`
+			: `This thread is locked to ${lockedModelLabel}, which no ready AI profile provides right now. Open Settings to connect one.`;
 	// One title on the locked pill: the model's identity, then what the lock
 	// means. The incompatible sentences already name the model, so the prefix
 	// would only say it twice.

--- a/apps/web-ui/src/components/product-shell.tsx
+++ b/apps/web-ui/src/components/product-shell.tsx
@@ -80,7 +80,7 @@ export function ConfigMenu({ onAiSetup, theme, onToggleTheme, active }: { onAiSe
 							setOpen(false);
 						}}
 					>
-						<span>AI setup</span>
+						<span>Settings</span>
 						<span className="menu-item-arrow" aria-hidden="true">→</span>
 					</button>
 					<button

--- a/apps/web-ui/src/components/room-model-picker.tsx
+++ b/apps/web-ui/src/components/room-model-picker.tsx
@@ -58,7 +58,7 @@ function inertGroup(profile: PersistentAgentAiProfileStatus): PickerGroup {
 		id: profile.id,
 		label: profile.label,
 		modelCount: profile.processes?.persistentRoom.models.length ?? 0,
-		note: profile.provider.configured ? "setup needed · finish in AI setup" : "not signed in · connect it in AI setup",
+		note: profile.provider.configured ? "setup needed · finish in Settings" : "not signed in · connect it in Settings",
 	};
 }
 
@@ -489,7 +489,7 @@ export function RoomModelPicker({ roomModels, modelStatusProfileId, value, onCha
 						{renderGroups.map(({ group, matches, collapsed, collapsible, headerId }) => {
 							if (group.kind === "inert") {
 								return (
-									<div key={group.id} className="model-picker-group inert" role="presentation" title="Sign in from AI setup to use this profile">
+									<div key={group.id} className="model-picker-group inert" role="presentation" title="Sign in from Settings to use this profile">
 										<div className="model-picker-group-head">
 											<span className="model-picker-group-text">
 												<span className="model-picker-group-name">{group.label}</span>


### PR DESCRIPTION
Pure copy rename, 12+/11- across 6 files, no logic touched.

- Gear menu item: **AI setup** → **Settings**
- Page: titled **Settings.**, with **AI provider** and **Web search** as same-level section headings (same `ai-setup-section-heading` structure for both)
- All strings directing users to "AI setup" (Help, rooms guide, model picker notes/tooltips, locked-thread tooltips, two error messages) now say "Settings"
- Internal ids, routes, props, and CSS classes keep their `ai-setup` names — rename is skin-deep by design

Verified: `tsc --noEmit` clean, `vite build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)