### PR TITLE
web-ui: hover texts that explain what each control does

### DIFF
--- a/apps/web-ui/src/App.tsx
+++ b/apps/web-ui/src/App.tsx
@@ -845,7 +845,7 @@ function AiProfileSwitcherSection({ status, onSelect, onRefresh, onRefreshAuth }
 								const title = !profile.ready
 									? "Sign in to this profile before using it"
 									: profile.active
-										? undefined
+										? "The active profile — your exxperts run on it"
 										: "Select this AI profile. New room threads start on it; standby threads keep their model";
 								return (
 									<div key={profile.id} className={`ai-profile-row-group${modelsOpen ? " open" : ""}${keyProfileId === profile.id ? " key-open" : ""}`}>
@@ -899,13 +899,14 @@ function AiProfileSwitcherSection({ status, onSelect, onRefresh, onRefreshAuth }
 													<button
 														className="ai-profile-models-toggle"
 														aria-expanded={modelsOpen}
+														title="Show or hide this profile's approved models"
 														onClick={() => setModelsOpenId(modelsOpen ? null : profile.id)}
 													>
 														{roomModelsLabel} {modelsOpen ? "▴" : "▾"}
 													</button>
 												)}
 												{signingIn ? (
-													<button className="ai-profile-foot-link" onClick={() => void login.cancel()}>Cancel</button>
+													<button className="ai-profile-foot-link" onClick={() => void login.cancel()} title="Stop this sign-in attempt">Cancel</button>
 												) : (
 													<>
 														{/* The key row carries its own Cancel now, for every row rather
@@ -926,6 +927,7 @@ function AiProfileSwitcherSection({ status, onSelect, onRefresh, onRefreshAuth }
 															aria-haspopup="menu"
 															aria-expanded={menuOpenId === profile.id}
 															aria-label={`Manage ${profile.label}`}
+															title={`Manage ${profile.label}: models, keys, sign-out`}
 															onClick={(e) => { if (menuOpenId === profile.id) { closeMenu(); } else { menuAnchorRef.current = e.currentTarget; setMenuOpenId(profile.id); setConfirmRemoveId(null); setKeyProfileId(null); } }}
 														>···</button>
 														{menuOpenId === profile.id && (
@@ -934,7 +936,7 @@ function AiProfileSwitcherSection({ status, onSelect, onRefresh, onRefreshAuth }
 																	<>
 																		<span className="ai-profile-menu-confirm">Remove {profile.label}? This {profile.provider.configured ? "signs out and deletes" : "deletes"} its approved models.</span>
 																		<button className="ai-profile-menu-item danger" role="menuitem" disabled={removing} onClick={() => void removeProfile(profile)}>{removing ? "Removing…" : "Remove"}</button>
-																		<button className="ai-profile-menu-item" role="menuitem" disabled={removing} onClick={() => setConfirmRemoveId(null)}>Keep it</button>
+																		<button className="ai-profile-menu-item" role="menuitem" disabled={removing} onClick={() => setConfirmRemoveId(null)} title="Cancel — keep this profile">Keep it</button>
 																	</>
 																) : (
 																	<>
@@ -943,18 +945,18 @@ function AiProfileSwitcherSection({ status, onSelect, onRefresh, onRefreshAuth }
 																		    the opened panel would be uncloseable. */}
 																		<button className="ai-profile-menu-item" role="menuitem" onClick={() => { setModelsOpenId(modelsOpen ? null : profile.id); closeMenu(); }}>{modelsOpen ? "Hide models" : "View models"}</button>
 																		{profile.kind !== "gateway" && (
-																			<button className="ai-profile-menu-item" role="menuitem" onClick={() => { setEditProfile(profile); closeMenu(); }}>Approve models</button>
+																			<button className="ai-profile-menu-item" role="menuitem" onClick={() => { setEditProfile(profile); closeMenu(); }} title="Choose which models rooms may use">Approve models</button>
 																		)}
 																		{profile.kind === "gateway" && (
 																			<>
 																				{/* Approve models edits the model set only; Edit gateway
 																				    owns the base URL and API key. */}
-																				<button className="ai-profile-menu-item" role="menuitem" onClick={() => { setGatewayApproveId(profile.id); closeMenu(); }}>Approve models</button>
-																				<button className="ai-profile-menu-item" role="menuitem" onClick={() => { setGatewayEdit({ id: profile.id, label: profile.label }); closeMenu(); }}>Edit gateway</button>
+																				<button className="ai-profile-menu-item" role="menuitem" onClick={() => { setGatewayApproveId(profile.id); closeMenu(); }} title="Choose which models rooms may use">Approve models</button>
+																				<button className="ai-profile-menu-item" role="menuitem" onClick={() => { setGatewayEdit({ id: profile.id, label: profile.label }); closeMenu(); }} title="Change the gateway URL or API key">Edit gateway</button>
 																			</>
 																		)}
 																		{profile.kind === "builtin" && profile.overridden && (
-																			<button className="ai-profile-menu-item" role="menuitem" onClick={() => { closeMenu(); void resetBuiltInModels(profile); }}>Reset to curated models</button>
+																			<button className="ai-profile-menu-item" role="menuitem" onClick={() => { closeMenu(); void resetBuiltInModels(profile); }} title="Drop the custom model list and restore the built-in catalog">Reset to curated models</button>
 																		)}
 																		{providerAcceptsApiKey(profile.provider.id) && profile.provider.configured && (
 																			<button className="ai-profile-menu-item" role="menuitem" onClick={() => { setKeyProfileId(profile.id); closeMenu(); }}>Replace API key</button>
@@ -1091,7 +1093,7 @@ function Landing({ onOpenSettings, onOpenDashboard, onOpenMemory, onOpenPersiste
 					<button type="button" className="section-help-btn" aria-label="How rooms work" title="How rooms work" onClick={() => setHelpOpen(true)}>?</button>
 				</div>
 				{aiProfileStatus && aiProfileStatus.ready === false && (
-					<button type="button" className="home-ai-profile-status setup-needed" onClick={() => onOpenSettings("ai-setup")}>
+					<button type="button" className="home-ai-profile-status setup-needed" onClick={() => onOpenSettings("ai-setup")} title="Open Settings to finish AI setup">
 						{aiProfileStatus.message}
 					</button>
 				)}
@@ -1247,7 +1249,7 @@ function ArchivedRoomsSection({ activeRoomCount, onRestored }: { activeRoomCount
 	return (
 		<section className="archived-rooms" aria-label="Archived rooms">
 			{rooms.length > 0 && (
-				<button type="button" className="archived-rooms-summary" aria-expanded={open} onClick={() => { setOpen((v) => !v); setArmedId(null); }}>
+				<button type="button" className="archived-rooms-summary" aria-expanded={open} title="Show or hide archived rooms" onClick={() => { setOpen((v) => !v); setArmedId(null); }}>
 					<span className="archived-rooms-title">Archived rooms ({rooms.length})</span>
 					<span className="archived-rooms-toggle" aria-hidden="true">{open ? "▾" : "▸"}</span>
 				</button>
@@ -1268,11 +1270,11 @@ function ArchivedRoomsSection({ activeRoomCount, onRestored }: { activeRoomCount
 								)}
 							</div>
 							<div className="archived-room-actions">
-								{armedId === room.id && <button type="button" className="rs-quiet" disabled={busy?.id === room.id} onClick={() => setArmedId(null)}>Keep it</button>}
-								<button type="button" className="rs-btn" disabled={busy?.id === room.id} onClick={() => void restoreRoom(room)}>
+								{armedId === room.id && <button type="button" className="rs-quiet" disabled={busy?.id === room.id} onClick={() => setArmedId(null)} title="Cancel — keep this room archived">Keep it</button>}
+								<button type="button" className="rs-btn" disabled={busy?.id === room.id} title="Bring this room back to Home" onClick={() => void restoreRoom(room)}>
 									{busy?.id === room.id && busy.action === "restore" ? "Restoring…" : "Restore"}
 								</button>
-								<button type="button" className="rs-btn rs-btn-danger" disabled={busy?.id === room.id} onClick={() => void deleteForever(room)}>
+								<button type="button" className="rs-btn rs-btn-danger" disabled={busy?.id === room.id} title="Erase this room and its files from this machine" onClick={() => void deleteForever(room)}>
 									{busy?.id === room.id && busy.action === "purge" ? "Deleting…" : "Delete forever"}
 								</button>
 							</div>
@@ -1350,8 +1352,8 @@ function ExportCollisionDialog({ collision, onClose }: { collision: ExportCollis
 				<p>A file called “{collision.fileName}” is already in {collision.place ?? "the chosen folder"}.</p>
 				<div className="checkpoint-preview-actions">
 					<button className="landing-action secondary" autoFocus onClick={onClose}>Cancel</button>
-					<button className="landing-action secondary" onClick={() => { onClose(); collision.onKeepBoth(); }}>Keep both</button>
-					<button className="rs-btn rs-btn-danger" onClick={() => { onClose(); collision.onReplace(); }}>Replace</button>
+					<button className="landing-action secondary" onClick={() => { onClose(); collision.onKeepBoth(); }} title="Save with a new name; the existing file stays">Keep both</button>
+					<button className="rs-btn rs-btn-danger" onClick={() => { onClose(); collision.onReplace(); }} title="Overwrite the existing file">Replace</button>
 				</div>
 			</section>
 		</div>
@@ -1449,8 +1451,8 @@ function TaskStoreGcBanner({ assessment, onReview, onDismiss }: { assessment: Ta
 	return (
 		<div className="task-store-gc-banner" role="status">
 			<span>Old specialist files are taking up {fmtMb(assessment.totalBytes)} — {fmtMb(assessment.proposal.reclaimBytes)} can be freed safely.</span>
-			<button className="landing-action secondary" onClick={onReview}>Review</button>
-			<button className="icon-btn" aria-label="Dismiss" onClick={onDismiss}>✕</button>
+			<button className="landing-action secondary" onClick={onReview} title="See which old task folders would be deleted">Review</button>
+			<button className="icon-btn" aria-label="Dismiss" title="Dismiss — nothing is deleted" onClick={onDismiss}>✕</button>
 		</div>
 	);
 }
@@ -1510,7 +1512,7 @@ function MaintainChooserShell({ target, memoryStatus, onAbsorb, onPrune, onRetur
 						</div>
 						<div className="maintain-choice-footer">
 							{recentCount !== null && <span className="maintain-choice-status" title={nothingToLearn ? undefined : "Memorizing needs a few remembered sessions; the check when you start confirms this is enough."}>{nothingToLearn ? "Nothing new to memorize right now" : `${recentCount} recent ${recentCount === 1 ? "session" : "sessions"} waiting`}</span>}
-							<button className="landing-action" disabled={nothingToLearn} title={nothingToLearn ? "Have a session with this room first." : undefined} onClick={onAbsorb}>Start memorizing</button>
+							<button className="landing-action" disabled={nothingToLearn} title={nothingToLearn ? "Have a session with this room first." : "Turn remembered sessions into lasting memory"} onClick={onAbsorb}>Start memorizing</button>
 						</div>
 					</article>
 					<article className="maintain-choice-card">
@@ -1520,7 +1522,7 @@ function MaintainChooserShell({ target, memoryStatus, onAbsorb, onPrune, onRetur
 							<p>Go over what {target.displayName} keeps long-term and tighten anything stale, redundant, or overgrown.</p>
 						</div>
 						<div className="maintain-choice-footer">
-							<button className="landing-action secondary" onClick={onPrune}>Start review</button>
+							<button className="landing-action secondary" onClick={onPrune} title="Tidy and tighten this room's long-term memory">Start review</button>
 						</div>
 					</article>
 				</section>
@@ -1824,8 +1826,8 @@ function StructuralReviewWorkflowShell({ state, loadingMessage, waitingMessage, 
 							{meaningfulMaintenanceWarnings(assessment.warnings).length > 0 && <div className="checkpoint-proposal-warnings">{meaningfulMaintenanceWarnings(assessment.warnings).map((warning) => <div key={warning}>{warning}</div>)}</div>}
 							<div className="checkpoint-preview-actions">
 								<button className="landing-action secondary" onClick={onAbort}>Cancel</button>
-								<button className="landing-action secondary" onClick={onDiscuss}>Discuss memory</button>
-								<button className="landing-action" onClick={onGenerate}>Draft memory update</button>
+								<button className="landing-action secondary" onClick={onDiscuss} title="Talk the assessment through first — the discussion itself isn't saved">Discuss memory</button>
+								<button className="landing-action" onClick={onGenerate} title="Generate the memory update for your review">Draft memory update</button>
 							</div>
 							{state.fastPathEnabled && <p className="checkpoint-footnote">Automatic maintenance is on · a clean draft is applied without a second review</p>}
 						</div>
@@ -2034,8 +2036,8 @@ function AbsorbWorkflowShell({ state, loadingMessage, waitingMessage, onAbort, o
 						{meaningfulMaintenanceWarnings(assessment.warnings).length > 0 && <div className="checkpoint-proposal-warnings">{meaningfulMaintenanceWarnings(assessment.warnings).map((warning) => <div key={warning}>{warning}</div>)}</div>}
 						<div className="checkpoint-preview-actions">
 							<button className="landing-action secondary" onClick={onAbort}>Cancel</button>
-							<button className="landing-action secondary" onClick={onDiscuss}>Discuss memory</button>
-							<button className="landing-action" onClick={onGenerate}>Draft memory update</button>
+							<button className="landing-action secondary" onClick={onDiscuss} title="Talk the assessment through first — the discussion itself isn't saved">Discuss memory</button>
+							<button className="landing-action" onClick={onGenerate} title="Generate the memory update for your review">Draft memory update</button>
 						</div>
 						{state.fastPathEnabled && <p className="checkpoint-footnote">Automatic maintenance is on · a clean draft is applied without a second review</p>}
 					</div>
@@ -2551,7 +2553,7 @@ function CheckpointPreviewShell({ chat, itemCount, rememberText, density, propos
 						</div>
 						{approvalResult.warnings.length > 0 && <div className="checkpoint-proposal-warnings">{approvalResult.warnings.map((warning) => <div key={warning}>{warning}</div>)}</div>}
 						<div className="checkpoint-preview-actions">
-							<button className="landing-action" onClick={onContinueAfterCheckpoint}>Continue working</button>
+							<button className="landing-action" onClick={onContinueAfterCheckpoint} title="Stay in this room on a fresh thread">Continue working</button>
 							<button className="landing-action secondary" onClick={onRestAfterCheckpoint}>Return Home</button>
 						</div>
 					</div>
@@ -2582,7 +2584,7 @@ function CheckpointPreviewShell({ chat, itemCount, rememberText, density, propos
 									{showFullEntry ? (
 										<div className="checkpoint-review-actions">
 											<button className="inline-action" onClick={() => setShowFullEntry(false)}>Hide full entry</button>
-											<button className="inline-action" onClick={() => setEditing(true)}>Edit</button>
+											<button className="inline-action" onClick={() => setEditing(true)} title="Edit the entry before saving">Edit</button>
 										</div>
 									) : (
 										<button className="inline-action checkpoint-full-entry-trigger" onClick={() => setShowFullEntry(true)}>Show full entry</button>
@@ -2619,7 +2621,7 @@ function CheckpointPreviewShell({ chat, itemCount, rememberText, density, propos
 						{honestyNoticesNode}
 						<div className="checkpoint-preview-actions">
 							<button className="landing-action" disabled={approvalLoading || !approvalReady} onClick={() => onApprove(approvedDraft)}>{approvalLoading ? "Saving…" : "Save to memory"}</button>
-							<button className="landing-action secondary" disabled={approvalLoading} onClick={confirmDiscard}>Discard</button>
+							<button className="landing-action secondary" disabled={approvalLoading} onClick={confirmDiscard} title="Throw away this draft — nothing is saved">Discard</button>
 						</div>
 						<p className="checkpoint-footnote">Saved only when you approve · automatic apply can be turned on in room settings</p>
 					</div>
@@ -7579,8 +7581,8 @@ export function App() {
 								{/* Hide only for the moment, never write the dismissed flag:
 								    the close-modal re-check re-shows the nudge if the user
 								    cancelled without setting a workspace. Only Dismiss burns it. */}
-								<button className="rs-btn" type="button" onClick={() => { setWorkspaceNudgeRoomId(null); openRoomSettings(); }}>Set workspace</button>
-								<button className="rs-quiet" type="button" onClick={dismissWorkspaceNudge}>Dismiss</button>
+								<button className="rs-btn" type="button" title="Choose the folder this room may read and write" onClick={() => { setWorkspaceNudgeRoomId(null); openRoomSettings(); }}>Set workspace</button>
+								<button className="rs-quiet" type="button" title="Hide this hint for good" onClick={dismissWorkspaceNudge}>Dismiss</button>
 							</div>
 						</div>
 					)}

--- a/apps/web-ui/src/App.tsx
+++ b/apps/web-ui/src/App.tsx
@@ -7259,13 +7259,14 @@ export function App() {
 				{
 					id: "connectors",
 					label: "Connectors",
+					title: "External tools your rooms can reach",
 					content: (
 						<div className="landing ai-setup-page connectors-page">
 							<ConnectorsPage />
 						</div>
 					),
 				},
-				{ id: "skills", label: "Skills", content: <SkillsPage /> },
+				{ id: "skills", label: "Skills", title: "Reusable instructions your rooms can follow", content: <SkillsPage /> },
 				...(remoteClient ? [] : [{
 					id: "remote" as const,
 					label: "Remote access",

--- a/apps/web-ui/src/components/ConnectorsPage.tsx
+++ b/apps/web-ui/src/components/ConnectorsPage.tsx
@@ -177,6 +177,7 @@ function ConnectorRow({ server, expanded, onToggle, onChanged, onNotice, readOnl
 						<button
 							className="inline-action"
 							disabled={busy !== null}
+							title="Check the server is reachable and list its tools"
 							onClick={() => void run("test", async () => {
 								const result = await testMcpServer(server.name);
 								setBusy(null);
@@ -255,7 +256,7 @@ function ConnectorRow({ server, expanded, onToggle, onChanged, onNotice, readOnl
 								>
 									{busy === "remove" ? "Removing…" : "Remove"}
 								</button>
-								<button className="inline-action connector-action-quiet" disabled={busy !== null} onClick={() => setConfirmRemove(false)}>Keep</button>
+								<button className="inline-action connector-action-quiet" disabled={busy !== null} title="Cancel — keep this connector" onClick={() => setConfirmRemove(false)}>Keep</button>
 							</>
 						) : (
 							<button className="inline-action connector-action-quiet" disabled={busy !== null} onClick={() => setConfirmRemove(true)}>Remove</button>

--- a/apps/web-ui/src/components/Dashboard.tsx
+++ b/apps/web-ui/src/components/Dashboard.tsx
@@ -304,8 +304,8 @@ export function Dashboard() {
 								<div className="sub">{activityMetric === "value" ? `Est. value per ${unit}, split by source.` : `Tokens per ${unit}.`}</div>
 							</div>
 							<div className="range-toggle" role="group" aria-label="Activity metric">
-								<button type="button" className={activityMetric === "tokens" ? "active" : ""} aria-pressed={activityMetric === "tokens"} onClick={() => setActivityMetric("tokens")}>Tokens</button>
-								<button type="button" className={activityMetric === "value" ? "active" : ""} aria-pressed={activityMetric === "value"} onClick={() => setActivityMetric("value")}>Value</button>
+								<button type="button" className={activityMetric === "tokens" ? "active" : ""} aria-pressed={activityMetric === "tokens"} title="Chart token counts" onClick={() => setActivityMetric("tokens")}>Tokens</button>
+								<button type="button" className={activityMetric === "value" ? "active" : ""} aria-pressed={activityMetric === "value"} title="Chart estimated cost at list prices" onClick={() => setActivityMetric("value")}>Value</button>
 							</div>
 						</div>
 						<StackedChart buckets={buckets} metric={activityMetric} unit={unit} />
@@ -383,6 +383,7 @@ export function Dashboard() {
 							className="recent-filter"
 							role="button"
 							tabIndex={0}
+							title="Clear this filter"
 							onClick={(e) => { e.stopPropagation(); setAgent("all"); }}
 							onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); e.stopPropagation(); setAgent("all"); } }}
 						>

--- a/apps/web-ui/src/components/Memory.tsx
+++ b/apps/web-ui/src/components/Memory.tsx
@@ -913,8 +913,8 @@ export function Memory({ onMaintain, maintainBlocked }: { onMaintain?: (target: 
 	return (
 		<div className="dashboard">
 			<div className="mem-tabs" role="tablist">
-				<button type="button" role="tab" aria-selected={tab === "overview"} className={tab === "overview" ? "active" : ""} onClick={() => setTab("overview")}>Overview</button>
-				<button type="button" role="tab" aria-selected={tab === "hivemind"} className={tab === "hivemind" ? "active" : ""} onClick={() => setTab("hivemind")}>HiveMind</button>
+				<button type="button" role="tab" aria-selected={tab === "overview"} className={tab === "overview" ? "active" : ""} title="What each room knows" onClick={() => setTab("overview")}>Overview</button>
+				<button type="button" role="tab" aria-selected={tab === "hivemind"} className={tab === "hivemind" ? "active" : ""} title="Ask questions across all your rooms' memory" onClick={() => setTab("hivemind")}>HiveMind</button>
 			</div>
 
 			{tab === "hivemind" && (
@@ -927,8 +927,8 @@ export function Memory({ onMaintain, maintainBlocked }: { onMaintain?: (target: 
 									<button type="button" className="mem-close" onClick={() => { setMessages([]); setAskError(null); }}>New chat</button>
 								)}
 								<div className="range-toggle" role="group" aria-label="Query mode">
-									<button type="button" className={askMode === "ask" ? "active" : ""} aria-pressed={askMode === "ask"} onClick={() => setAskMode("ask")}>Ask</button>
-									<button type="button" className={askMode === "find" ? "active" : ""} aria-pressed={askMode === "find"} onClick={() => setAskMode("find")}>Find text</button>
+									<button type="button" className={askMode === "ask" ? "active" : ""} aria-pressed={askMode === "ask"} title="Ask a question — the AI answers from memory" onClick={() => setAskMode("ask")}>Ask</button>
+									<button type="button" className={askMode === "find" ? "active" : ""} aria-pressed={askMode === "find"} title="Search memory for exact text — local, no model" onClick={() => setAskMode("find")}>Find text</button>
 								</div>
 								<span className="mem-measured" style={{ color: "var(--muted)", borderColor: "var(--border)" }}>{askMode === "ask" ? `Read-only · ${scopeLabel}` : "Local · no model"}</span>
 							</div>
@@ -938,9 +938,9 @@ export function Memory({ onMaintain, maintainBlocked }: { onMaintain?: (target: 
 							{askMode === "ask" && data.rooms.length > 1 && (
 								<div className="mem-scope">
 									<span className="mem-scope-label">Exxperts</span>
-									<button type="button" className={`mem-scope-chip${scope.size === 0 ? " active" : ""}`} onClick={() => setScope(new Set())}>All exxperts</button>
+									<button type="button" className={`mem-scope-chip${scope.size === 0 ? " active" : ""}`} title="Answer from every room's memory" onClick={() => setScope(new Set())}>All exxperts</button>
 									{data.rooms.map((r) => (
-										<button key={r.id} type="button" className={`mem-scope-chip${scope.has(r.id) ? " active" : ""}`} onClick={() => toggleScopeRoom(r.id)}>{r.displayName}</button>
+										<button key={r.id} type="button" className={`mem-scope-chip${scope.has(r.id) ? " active" : ""}`} title={`Include or exclude ${r.displayName}'s memory`} onClick={() => toggleScopeRoom(r.id)}>{r.displayName}</button>
 									))}
 								</div>
 							)}
@@ -1084,7 +1084,7 @@ export function Memory({ onMaintain, maintainBlocked }: { onMaintain?: (target: 
 									{data.rooms.filter((r) => r.needsAbsorb).map((r) => {
 										const blocked = maintainBlocked?.(r.id) ?? null;
 										return (
-											<button key={r.id} type="button" className="mem-review-btn" disabled={!!blocked} title={blocked ?? undefined} onClick={() => onMaintain({ agentId: r.id, displayName: r.displayName })}>
+											<button key={r.id} type="button" className="mem-review-btn" disabled={!!blocked} title={blocked ?? `Turn ${r.displayName}'s remembered sessions into lasting memory`} onClick={() => onMaintain({ agentId: r.id, displayName: r.displayName })}>
 												{r.displayName}: memorize →
 											</button>
 										);
@@ -1320,7 +1320,7 @@ export function Memory({ onMaintain, maintainBlocked }: { onMaintain?: (target: 
 									<div className="dash-section-head" style={{ marginBottom: 0 }}>
 										<div className="chart-head mem-head-row"><h2>Memory map</h2>{past && <span className="mem-asof">as of {fmtDayShort(past.at)}</span>}</div>
 										<div className="mem-panel-actions">
-											<button type="button" className="mem-close" onClick={openFullMemory}>Read all →</button>
+											<button type="button" className="mem-close" title="Open the full memory document" onClick={openFullMemory}>Read all →</button>
 										</div>
 									</div>
 									<div className="sub" style={{ marginBottom: 6 }}>{past ? "Composition that day, same measuring as today. Click a section to read what it held." : "Composition by estimated token weight. Click a section to read what's inside."}</div>

--- a/apps/web-ui/src/components/RoomConnectorsSection.tsx
+++ b/apps/web-ui/src/components/RoomConnectorsSection.tsx
@@ -121,7 +121,7 @@ export function RoomConnectorsSection({ status }: { status: PersistentAgentStatu
 										)}
 									</div>
 									<div className="room-skills-row-actions">
-										<button className="rs-quiet" disabled={busyName === entry.name} onClick={() => void toggle(entry.name, "revoke")}>
+										<button className="rs-quiet" disabled={busyName === entry.name} title="Disconnect from this room — the connector stays configured" onClick={() => void toggle(entry.name, "revoke")}>
 											{busyName === entry.name ? "Removing…" : "Remove"}
 										</button>
 									</div>
@@ -159,7 +159,7 @@ export function RoomConnectorsSection({ status }: { status: PersistentAgentStatu
 												)}
 											</div>
 											<div className="room-skills-row-actions">
-												<button className="rs-btn" disabled={busyName === name} onClick={() => void toggle(name, "grant")}>
+												<button className="rs-btn" disabled={busyName === name} title="Let this room use this connector" onClick={() => void toggle(name, "grant")}>
 													{busyName === name ? "Enabling…" : "Enable"}
 												</button>
 											</div>

--- a/apps/web-ui/src/components/RoomDangerZone.tsx
+++ b/apps/web-ui/src/components/RoomDangerZone.tsx
@@ -104,7 +104,7 @@ export function RoomDangerZone({ status, visible, onArchive, onPurge }: {
 					)}
 				</div>
 				<div className="rs-pane-actions">
-					{armed && <button className="rs-quiet" type="button" disabled={submitting !== null} onClick={() => setArmed(false)}>Keep it</button>}
+					{armed && <button className="rs-quiet" type="button" disabled={submitting !== null} onClick={() => setArmed(false)} title="Cancel — keep this room">Keep it</button>}
 					<button className="rs-btn rs-btn-danger" disabled={submitting !== null} onClick={() => void submitPurge()}>
 						{submitting === "purge" ? "Deleting…" : armed ? "Delete forever" : "Delete permanently"}
 					</button>

--- a/apps/web-ui/src/components/RoomScheduledTasksSection.tsx
+++ b/apps/web-ui/src/components/RoomScheduledTasksSection.tsx
@@ -757,7 +757,7 @@ function ScheduleJobCard({
 					{error && <p className="workspaces-error">{error}</p>}
 					<div className="room-schedules-job-actions">
 						<button className="rs-quiet" type="button" onClick={onEdit} disabled={actionDisabled}>Edit</button>
-						<button className="rs-quiet" type="button" onClick={onToggleEnabled} disabled={actionDisabled}>{toggling ? "Saving…" : job.enabled ? "Disable" : "Enable"}</button>
+						<button className="rs-quiet" type="button" onClick={onToggleEnabled} disabled={actionDisabled} title={job.enabled ? "Pause this schedule — the record stays" : "Turn this schedule back on"}>{toggling ? "Saving…" : job.enabled ? "Disable" : "Enable"}</button>
 						<button className="rs-quiet rs-quiet-danger" type="button" onClick={onRequestDelete} disabled={actionDisabled}>Delete</button>
 					</div>
 					{confirmingDelete && (

--- a/apps/web-ui/src/components/RoomSkillsSection.tsx
+++ b/apps/web-ui/src/components/RoomSkillsSection.tsx
@@ -215,7 +215,7 @@ export function RoomSkillsSection({ status, onOpenSkillsLibrary }: { status: Per
 												{reviewLoadingName === state.name ? "Loading…" : "Review changes"}
 											</button>
 										)}
-										<button className="rs-quiet" disabled={busyName === state.name} onClick={() => void toggle(state.name, "disable")}>
+										<button className="rs-quiet" disabled={busyName === state.name} title="Disable for this room — the skill stays in your library" onClick={() => void toggle(state.name, "disable")}>
 											{busyName === state.name ? "Removing…" : "Remove"}
 										</button>
 									</div>
@@ -245,7 +245,7 @@ export function RoomSkillsSection({ status, onOpenSkillsLibrary }: { status: Per
 											{skill.description && <span className="room-skills-desc">{skill.description}</span>}
 										</div>
 										<div className="room-skills-row-actions">
-											<button className="rs-btn" disabled={busyName === skill.name} onClick={() => void toggle(skill.name, "enable")}>
+											<button className="rs-btn" disabled={busyName === skill.name} title="Let this room use this skill" onClick={() => void toggle(skill.name, "enable")}>
 												{busyName === skill.name ? "Enabling…" : "Enable"}
 											</button>
 										</div>

--- a/apps/web-ui/src/components/RoomWorkspaceSection.tsx
+++ b/apps/web-ui/src/components/RoomWorkspaceSection.tsx
@@ -319,7 +319,7 @@ export function RoomWorkspaceSection({ status, onDirtyChange }: { status: Persis
 				{!editing && policy && (
 					<div className="rs-pane-actions">
 						<button className="rs-btn" disabled={!canManageWorkspace || loading || saving} onClick={startOrCancelEditing}>Edit workspace</button>
-						<button className="rs-quiet" disabled={!canManageWorkspace || loading || saving} onClick={() => void clearWorkspaceDefault()}>{saving ? "Updating…" : "Clear"}</button>
+						<button className="rs-quiet" disabled={!canManageWorkspace || loading || saving} title="Remove the saved workspace folder" onClick={() => void clearWorkspaceDefault()}>{saving ? "Updating…" : "Clear"}</button>
 					</div>
 				)}
 			</header>
@@ -361,8 +361,8 @@ export function RoomWorkspaceSection({ status, onDirtyChange }: { status: Persis
 						<div className="workspaces-tool-options">
 							<strong>Access mode</strong>
 							<div className="workspace-mode-segments" role="radiogroup" aria-label="Workspace access mode">
-								<button type="button" role="radio" aria-checked={draftAccessMode === "localFiles"} className={`workspace-mode-segment${draftAccessMode === "localFiles" ? " active" : ""}`} disabled={saving} onClick={() => changeAccessMode("localFiles")}>Full access</button>
-								<button type="button" role="radio" aria-checked={draftAccessMode === "bounded"} className={`workspace-mode-segment${draftAccessMode === "bounded" ? " active" : ""}`} disabled={saving} onClick={() => changeAccessMode("bounded")}>Bounded workspace</button>
+								<button type="button" role="radio" aria-checked={draftAccessMode === "localFiles"} className={`workspace-mode-segment${draftAccessMode === "localFiles" ? " active" : ""}`} disabled={saving} title={accessModeHint("localFiles")} onClick={() => changeAccessMode("localFiles")}>Full access</button>
+								<button type="button" role="radio" aria-checked={draftAccessMode === "bounded"} className={`workspace-mode-segment${draftAccessMode === "bounded" ? " active" : ""}`} disabled={saving} title={accessModeHint("bounded")} onClick={() => changeAccessMode("bounded")}>Bounded workspace</button>
 							</div>
 							<p className="workspaces-session-note">{accessModeHint(draftAccessMode)}</p>
 						</div>

--- a/apps/web-ui/src/components/add-provider-panel.tsx
+++ b/apps/web-ui/src/components/add-provider-panel.tsx
@@ -276,7 +276,7 @@ export function ConfigureProfileModal({ providerId, providerName, existingProfil
 							</div>
 							<div className="configure-profile-field">
 								<h3>Memorize</h3>
-								<select className="configure-profile-select" value={learnModel} onChange={(e) => setLearnModel(e.target.value)} aria-label="Memorize model">
+								<select className="configure-profile-select" value={learnModel} onChange={(e) => setLearnModel(e.target.value)} aria-label="Memorize model" title="The model that turns remembered sessions into lasting memory">
 									{catalog.models.map((model) => (
 										<option key={model.id} value={model.id}>{catalogModelName(model)}{model.suggestedDefault ? " (suggested)" : ""}</option>
 									))}
@@ -284,7 +284,7 @@ export function ConfigureProfileModal({ providerId, providerName, existingProfil
 							</div>
 							<div className="configure-profile-field">
 								<h3>Review</h3>
-								<select className="configure-profile-select" value={reviewMemoryModel} onChange={(e) => setReviewMemoryModel(e.target.value)} aria-label="Review model">
+								<select className="configure-profile-select" value={reviewMemoryModel} onChange={(e) => setReviewMemoryModel(e.target.value)} aria-label="Review model" title="The model that reviews and tidies long-term memory">
 									{catalog.models.map((model) => (
 										<option key={model.id} value={model.id}>{catalogModelName(model)}{model.suggestedDefault ? " (suggested)" : ""}</option>
 									))}
@@ -709,6 +709,7 @@ export function GatewayModelApprovalList({ drafts, onChange, ariaLabel, askedGat
 								<label className="gateway-adjust-field gateway-model-window">
 									<span className="gateway-model-window-label">context</span>
 									<input
+										title="How many tokens the model can hold — drives the room's context meter and compaction"
 										className={`launcher-path-input gateway-model-window-input${windowError ? " invalid" : ""}`}
 										type="text"
 										inputMode="numeric"
@@ -979,7 +980,7 @@ export function GatewayConfigModal({ gatewayId, knownLabel, onClose, onSaved }: 
 					</div>
 					<div className="configure-profile-field">
 						<h3>Memorize &amp; Review</h3>
-						<select className="configure-profile-select" value={effectiveMaintenanceModel} onChange={(e) => setMaintenanceModel(e.target.value)} aria-label="Maintenance model" disabled={approvedIds.length === 0}>
+						<select className="configure-profile-select" value={effectiveMaintenanceModel} onChange={(e) => setMaintenanceModel(e.target.value)} aria-label="Maintenance model" title="The model that runs Memorize and Review" disabled={approvedIds.length === 0}>
 							{maintenanceEligibleIds.map((id) => (
 								<option key={id} value={id}>{catalogModelName({ id })}</option>
 							))}
@@ -1189,7 +1190,7 @@ export function GatewayApproveModelsModal({ gatewayId, onClose, onSaved }: { gat
 							</div>
 							<div className="configure-profile-field">
 								<h3>Memorize and Review</h3>
-								<select className="configure-profile-select" value={effectiveMaintenanceModel} onChange={(e) => setMaintenanceModel(e.target.value)} aria-label="Maintenance model" disabled={approvedIds.length === 0}>
+								<select className="configure-profile-select" value={effectiveMaintenanceModel} onChange={(e) => setMaintenanceModel(e.target.value)} aria-label="Maintenance model" title="The model that runs Memorize and Review" disabled={approvedIds.length === 0}>
 									{maintenanceEligibleIds.map((id) => (
 										<option key={id} value={id}>{catalogModelName({ id })}</option>
 									))}

--- a/apps/web-ui/src/components/asset-viewer-footer.tsx
+++ b/apps/web-ui/src/components/asset-viewer-footer.tsx
@@ -133,7 +133,7 @@ export function AssetViewerFooter({ taskId, artifact, userFileName, roomId, canI
 							}
 						}}
 					/>
-					<button type="button" className="artifact-viewer-action" disabled={iteratePending || !brief.trim()} onClick={submitIterate}>
+					<button type="button" className="artifact-viewer-action" disabled={iteratePending || !brief.trim()} title="Ask the room to revise this file" onClick={submitIterate}>
 						{iteratePending ? "Starting…" : "Go"}
 					</button>
 				</div>

--- a/apps/web-ui/src/components/assets-panel.tsx
+++ b/apps/web-ui/src/components/assets-panel.tsx
@@ -67,7 +67,7 @@ export function AssetsPanel({ rows, selectedTaskId, onSelect, onStopRunning, onR
 	};
 	return (
 		<div className="sidebar-assets" aria-label="Files in this room">
-			<button className="assets-head" aria-expanded={!collapsed} onClick={() => setCollapsed((v) => !v)}>
+			<button className="assets-head" aria-expanded={!collapsed} title="Show or hide the files this room has made and received" onClick={() => setCollapsed((v) => !v)}>
 				<span className="assets-caret">{collapsed ? "▸" : "▾"}</span>
 				<span className="assets-head-label">Files</span>
 				<span className="assets-count">{rows.length}</span>

--- a/apps/web-ui/src/components/delegation-card.tsx
+++ b/apps/web-ui/src/components/delegation-card.tsx
@@ -279,7 +279,7 @@ export function ConsultDock({ state, onMinimize, onOpen, onStop, onDismiss, onTr
 			</span>
 		);
 		footerActions = (
-			<button className="btn" type="button" onClick={onStop}>
+			<button className="btn" type="button" onClick={onStop} title="Stop the answer — what has arrived stays">
 				Stop
 			</button>
 		);
@@ -294,10 +294,10 @@ export function ConsultDock({ state, onMinimize, onOpen, onStop, onDismiss, onTr
 		footerMeta = undefined;
 		footerActions = (
 			<>
-				<button className="btn" type="button" onClick={onDismiss}>
+				<button className="btn" type="button" onClick={onDismiss} title="Discard this consult — nothing enters the conversation">
 					Dismiss
 				</button>
-				<button className="btn btn-primary" type="button" onClick={onTransfer}>
+				<button className="btn btn-primary" type="button" onClick={onTransfer} title="Bring this exchange into the room's conversation">
 					Transfer to thread
 				</button>
 			</>
@@ -324,15 +324,15 @@ export function ConsultDock({ state, onMinimize, onOpen, onStop, onDismiss, onTr
 		subline = state.errorMessage ?? (state.phase === "stopped" ? "Consult stopped." : "Consult failed.");
 		footerActions = showTransfer ? (
 			<>
-				<button className="btn" type="button" onClick={onDismiss}>
+				<button className="btn" type="button" onClick={onDismiss} title="Discard this consult — nothing enters the conversation">
 					Dismiss
 				</button>
-				<button className="btn btn-primary" type="button" onClick={onTransfer}>
+				<button className="btn btn-primary" type="button" onClick={onTransfer} title="Bring this exchange into the room's conversation">
 					Transfer to thread
 				</button>
 			</>
 		) : (
-			<button className="btn" type="button" onClick={onDismiss}>
+			<button className="btn" type="button" onClick={onDismiss} title="Discard this consult — nothing enters the conversation">
 				Dismiss
 			</button>
 		);

--- a/apps/web-ui/src/components/in-room-chat.tsx
+++ b/apps/web-ui/src/components/in-room-chat.tsx
@@ -778,7 +778,7 @@ export function InRoomChatShellView({
 							/>
 						</div>
 						{showJumpToLatest && (
-							<button type="button" className="jump-to-latest" onClick={jumpToLatest} aria-label="Jump to latest message">
+							<button type="button" className="jump-to-latest" onClick={jumpToLatest} aria-label="Jump to latest message" title="Jump to the newest message">
 								↓ Latest
 							</button>
 						)}

--- a/apps/web-ui/src/components/launcher-room-card.tsx
+++ b/apps/web-ui/src/components/launcher-room-card.tsx
@@ -374,7 +374,7 @@ export function PersistentAgentCard({ status, modelStatus, aiProfileStatus, thre
 			<div className="persistent-agent-actions">
 				<div className="persistent-agent-primary-actions">
 					{state === "missing" ? (
-						<button className="landing-action" disabled>Unavailable</button>
+						<button className="landing-action" disabled title="This room's files are missing on this machine">Unavailable</button>
 					) : hasStandbyThread ? (
 						canSwitchResume && switchTargetProfile ? (
 							<button
@@ -418,7 +418,7 @@ export function PersistentAgentCard({ status, modelStatus, aiProfileStatus, thre
 				</div>
 				<div className="persistent-agent-secondary-actions">
 					<button className="inline-action" disabled={!canMaintain} title={canMaintain ? `Fold ${label}'s recent activity into long-term memory. Routine housekeeping, not an error.` : maintainDisabledReason} onClick={() => status && onMaintain({ agentId: status.id, displayName: label })}>Maintain</button>
-					{status && (status.errors.length > 0 || status.warnings.length > 0) && <button className="inline-action" onClick={() => setExpanded((v) => !v)}>{expanded ? "Hide" : "Details"}</button>}
+					{status && (status.errors.length > 0 || status.warnings.length > 0) && <button className="inline-action" title={expanded ? "Hide the details" : "Show what needs attention"} onClick={() => setExpanded((v) => !v)}>{expanded ? "Hide" : "Details"}</button>}
 				</div>
 				{state !== "missing" && (
 					<div className={`persistent-agent-model${hasStandbyThread ? " locked" : showModelPicker ? "" : " unavailable"}`}>

--- a/apps/web-ui/src/components/product-shell.tsx
+++ b/apps/web-ui/src/components/product-shell.tsx
@@ -116,7 +116,7 @@ export function ConfigMenu({ onSettings, theme, onToggleTheme }: { onSettings: (
 								Update to v{update.available}
 							</button>
 							{update.dotVisible && (
-								<button className="menu-meta-dismiss" onClick={update.dismiss}>Dismiss</button>
+								<button className="menu-meta-dismiss" onClick={update.dismiss} title="Hide the update dot — the update stays available here">Dismiss</button>
 							)}
 						</div>
 					)}
@@ -130,6 +130,7 @@ export function ConfigMenu({ onSettings, theme, onToggleTheme }: { onSettings: (
 			<button
 				className="sidebar-config-gear"
 				aria-label={update.dotVisible ? "Settings, update available" : "Settings"}
+				title={update.dotVisible ? "Settings — update available" : "Settings"}
 				aria-haspopup="menu"
 				aria-expanded={open}
 				onClick={() => setOpen((v) => !v)}
@@ -178,15 +179,15 @@ export function ProductSidebar({ onHome, onSettings, onDashboard, onMemory, them
 			</div>
 			<nav className="product-nav" aria-label="Product navigation">
 				<div className="product-nav-section">
-					<button className={`list-btn ${active === "home" ? "active" : ""}`} onClick={onHome}>Rooms</button>
+					<button className={`list-btn ${active === "home" ? "active" : ""}`} onClick={onHome} title="Your rooms — one exxpert per topic">Rooms</button>
 				</div>
 				{onMemory && (
 					<div className="product-nav-section">
-						<button className={`list-btn ${active === "memory" ? "active" : ""}`} onClick={onMemory}>Memory</button>
+						<button className={`list-btn ${active === "memory" ? "active" : ""}`} onClick={onMemory} title="What your rooms know, and questions across all of it">Memory</button>
 					</div>
 				)}
 				<div className="product-nav-section">
-					<button className={`list-btn ${active === "dashboard" ? "active" : ""}`} onClick={onDashboard}>Wallet</button>
+					<button className={`list-btn ${active === "dashboard" ? "active" : ""}`} onClick={onDashboard} title="What your exxperts spend — API costs and plan usage">Wallet</button>
 				</div>
 			</nav>
 			{/* No connection status here on purpose: a healthy app says nothing

--- a/apps/web-ui/src/components/room-model-picker.tsx
+++ b/apps/web-ui/src/components/room-model-picker.tsx
@@ -525,6 +525,7 @@ export function RoomModelPicker({ roomModels, modelStatusProfileId, value, onCha
 											data-picker-item
 											tabIndex={showFilter ? -1 : 0}
 											aria-expanded={!collapsed}
+											title="Show or hide this profile's models"
 											onClick={() => setToggledGroups((prev) => ({ ...prev, [group.id]: collapsed }))}
 										>
 											{headBody}

--- a/apps/web-ui/src/components/settings-overlay.tsx
+++ b/apps/web-ui/src/components/settings-overlay.tsx
@@ -3,7 +3,7 @@ import { useEscapeKey } from "./use-escape-key";
 
 export type SettingsSection = "ai-setup" | "web-search" | "connectors" | "skills" | "remote";
 
-export type SettingsOverlaySectionDef = { id: SettingsSection; label: string; content: ReactNode };
+export type SettingsOverlaySectionDef = { id: SettingsSection; label: string; title?: string; content: ReactNode };
 
 /**
  * The one Settings surface. A centered modal over whatever the user was
@@ -38,6 +38,7 @@ export function SettingsOverlay({ sections, active, onSelect, onClose, initialMo
 								key={section.id}
 								type="button"
 								data-section={section.id}
+								title={section.title}
 								className={`list-btn ${section.id === activeSection?.id ? "active" : ""}`}
 								aria-current={section.id === activeSection?.id ? "page" : undefined}
 								onClick={() => {

--- a/apps/web-ui/src/components/task-run-view.tsx
+++ b/apps/web-ui/src/components/task-run-view.tsx
@@ -54,7 +54,7 @@ export function TaskRunView({ state, onStop, onClose, maximized, onToggleMaximiz
 						>
 							{maximized ? "⤡" : "⤢"}
 						</button>
-						<button type="button" className="artifact-viewer-close" onClick={onClose} aria-label="Close run view. The task keeps running.">
+						<button type="button" className="artifact-viewer-close" onClick={onClose} aria-label="Close run view. The task keeps running." title="Close — the task keeps running">
 							✕
 						</button>
 					</div>


### PR DESCRIPTION
## What

76 `title` attributes across 18 files. Copy only — no logic, ids, or classes touched.

A full sweep of the web UI found ~380 buttons with only ~150 tooltips. This adds short, precise hover texts wherever the control's function or consequence wasn't visible:

- **Sidebar / gear menu** — nav items gloss their product nouns (Wallet: "What your exxperts spend — API costs and plan usage"), the ⚙ icon and update-dot Dismiss name themselves.
- **Settings** — profile rows (incl. the active one), the ··· manage menu ("Approve models", "Edit gateway", "Reset to curated models"), model selects and the gateway context-window input.
- **Home** — the "AI setup needed" pill says it opens Settings; archived-room actions spell out their consequence ("Delete forever" erases from this machine).
- **Memorize / Review / Remember** — "Discuss memory" notes the discussion isn't saved; Discard, Edit, Continue working say what happens.
- **Room view & settings** — consult cards (Stop keeps what arrived, Transfer enters the conversation), skill/connector Enable/Remove clarify per-room scope, workspace access modes reuse the existing hint copy.
- **Elsewhere** — Wallet chart toggles, connector Test, schedule Disable/Enable, task-run close ("the task keeps running").

Deliberately skipped: self-explanatory labels (Cancel, Save), plain ✕ closes, controls with hint text beside them, and the info-`i` component that renders its own tooltip.

## Verification

- `tsc --noEmit` clean
- `vite build` green
- diff audited: every added line is a `title` attribute
