### PR TITLE
web-ui: appearance can follow the system's light or dark mode

### DIFF
--- a/apps/web-ui/src/App.tsx
+++ b/apps/web-ui/src/App.tsx
@@ -14,7 +14,7 @@ import { InRoomChatShellView } from "./components/in-room-chat";
 import { CreateRoomPanel } from "./components/create-room-panel";
 import { useEscapeKey } from "./components/use-escape-key";
 import { PersistentAgentCard } from "./components/launcher-room-card";
-import { ProductSidebar, type ThemeMode } from "./components/product-shell";
+import { ProductSidebar, type AppearancePreference, type ThemeMode } from "./components/product-shell";
 import { SettingsOverlay, type SettingsSection } from "./components/settings-overlay";
 import { WhatsNewDialog } from "./components/whats-new-dialog";
 import { useRemoteClientContext } from "./remote-client-context";
@@ -1046,7 +1046,7 @@ function AiProfileSwitcherSection({ status, onSelect, onRefresh, onRefreshAuth }
 	);
 }
 
-function Landing({ onOpenSettings, onOpenDashboard, onOpenMemory, onOpenPersistentAgent, onResumePersistentAgent, onMaintainPersistentAgent, onCreatePersistentAgent, onArchiveRoom, onPurgeRoom, onMementoForget, onRecordPreferredModel, modelStatus, persistentAgentStatuses, persistentThread, persistentLive, persistentResumeError, onRefreshPersistentAgent, theme, onToggleTheme, aiProfileStatus: aiProfileSelection, onSelectAiProfile, standbyLockedModels, backgroundReadyRooms, purgingRooms }: { onOpenSettings: (section?: SettingsSection) => void; onOpenDashboard: () => void; onOpenMemory: () => void; onOpenPersistentAgent: (status: PersistentAgentStatus, model: WebChatModelOption) => Promise<void> | void; onResumePersistentAgent: (status: PersistentAgentStatus) => Promise<void> | void; onMaintainPersistentAgent: (target: MaintainTarget) => void; onCreatePersistentAgent: (request: PersistentAgentCreateRequest) => Promise<void>; onArchiveRoom: (agentId: PersistentAgentId, confirmation: string) => Promise<PersistentAgentArchiveResponse>; onPurgeRoom: (agentId: PersistentAgentId, confirmation: string) => Promise<PersistentAgentPurgeResponse>; onMementoForget: (agentId: PersistentAgentId) => void; onRecordPreferredModel?: (agentId: PersistentAgentId, model: { provider: string; model: string }) => void; modelStatus: WebChatModelStatus | null; persistentAgentStatuses: PersistentAgentStatus[]; persistentThread: PersistentAgentThread | null; persistentLive: boolean; persistentResumeError: string | null; onRefreshPersistentAgent: () => void; theme: ThemeMode; onToggleTheme: () => void; aiProfileStatus: PersistentAgentAiProfileSelectionStatus | null; onSelectAiProfile: (profileId: string) => Promise<void>; standbyLockedModels?: Array<{ provider: string; model: string }>; backgroundReadyRooms?: ReadonlySet<PersistentAgentId>; purgingRooms?: ReadonlySet<PersistentAgentId> }) {
+function Landing({ onOpenSettings, onOpenDashboard, onOpenMemory, onOpenPersistentAgent, onResumePersistentAgent, onMaintainPersistentAgent, onCreatePersistentAgent, onArchiveRoom, onPurgeRoom, onMementoForget, onRecordPreferredModel, modelStatus, persistentAgentStatuses, persistentThread, persistentLive, persistentResumeError, onRefreshPersistentAgent, theme, appearance, onSetAppearance, aiProfileStatus: aiProfileSelection, onSelectAiProfile, standbyLockedModels, backgroundReadyRooms, purgingRooms }: { onOpenSettings: (section?: SettingsSection) => void; onOpenDashboard: () => void; onOpenMemory: () => void; onOpenPersistentAgent: (status: PersistentAgentStatus, model: WebChatModelOption) => Promise<void> | void; onResumePersistentAgent: (status: PersistentAgentStatus) => Promise<void> | void; onMaintainPersistentAgent: (target: MaintainTarget) => void; onCreatePersistentAgent: (request: PersistentAgentCreateRequest) => Promise<void>; onArchiveRoom: (agentId: PersistentAgentId, confirmation: string) => Promise<PersistentAgentArchiveResponse>; onPurgeRoom: (agentId: PersistentAgentId, confirmation: string) => Promise<PersistentAgentPurgeResponse>; onMementoForget: (agentId: PersistentAgentId) => void; onRecordPreferredModel?: (agentId: PersistentAgentId, model: { provider: string; model: string }) => void; modelStatus: WebChatModelStatus | null; persistentAgentStatuses: PersistentAgentStatus[]; persistentThread: PersistentAgentThread | null; persistentLive: boolean; persistentResumeError: string | null; onRefreshPersistentAgent: () => void; theme: ThemeMode; appearance: AppearancePreference; onSetAppearance: (pref: AppearancePreference) => void; aiProfileStatus: PersistentAgentAiProfileSelectionStatus | null; onSelectAiProfile: (profileId: string) => Promise<void>; standbyLockedModels?: Array<{ provider: string; model: string }>; backgroundReadyRooms?: ReadonlySet<PersistentAgentId>; purgingRooms?: ReadonlySet<PersistentAgentId> }) {
 	const [createOpen, setCreateOpen] = useState(false);
 	useEscapeKey(() => setCreateOpen(false), createOpen);
 	const [settingsRoomId, setSettingsRoomId] = useState<PersistentAgentId | null>(null);
@@ -1080,7 +1080,7 @@ function Landing({ onOpenSettings, onOpenDashboard, onOpenMemory, onOpenPersiste
 
 	return (
 		<div className="landing-shell with-product-sidebar">
-			<ProductSidebar onHome={() => {}} onSettings={onOpenSettings} onDashboard={onOpenDashboard} onMemory={onOpenMemory} theme={theme} onToggleTheme={onToggleTheme} active="home" />
+			<ProductSidebar onHome={() => {}} onSettings={onOpenSettings} onDashboard={onOpenDashboard} onMemory={onOpenMemory} theme={theme} appearance={appearance} onSetAppearance={onSetAppearance} active="home" />
 			<div className="landing home-page">
 			<section className="landing-hero">
 				<div className="landing-hero-head">
@@ -1286,10 +1286,10 @@ function ArchivedRoomsSection({ activeRoomCount, onRestored }: { activeRoomCount
 	);
 }
 
-function MemoryShell({ onHome, onSettings, onDashboard, onMaintain, maintainBlocked, theme, onToggleTheme }: { onHome: () => void; onSettings: (section?: SettingsSection) => void; onDashboard: () => void; onMaintain: (target: MaintainTarget) => void; maintainBlocked?: (agentId: PersistentAgentId) => string | null; theme: ThemeMode; onToggleTheme: () => void }) {
+function MemoryShell({ onHome, onSettings, onDashboard, onMaintain, maintainBlocked, theme, appearance, onSetAppearance }: { onHome: () => void; onSettings: (section?: SettingsSection) => void; onDashboard: () => void; onMaintain: (target: MaintainTarget) => void; maintainBlocked?: (agentId: PersistentAgentId) => string | null; theme: ThemeMode; appearance: AppearancePreference; onSetAppearance: (pref: AppearancePreference) => void }) {
 	return (
 		<div className="landing-shell with-product-sidebar">
-			<ProductSidebar onHome={onHome} onSettings={onSettings} onDashboard={onDashboard} onMemory={() => {}} theme={theme} onToggleTheme={onToggleTheme} active="memory" />
+			<ProductSidebar onHome={onHome} onSettings={onSettings} onDashboard={onDashboard} onMemory={() => {}} theme={theme} appearance={appearance} onSetAppearance={onSetAppearance} active="memory" />
 			<div className="landing dashboard-page">
 				<section className="landing-hero">
 					<h1>Memory.</h1>
@@ -2770,14 +2770,27 @@ export function App() {
 	// A remote device never sees the Remote access section: the server refuses
 	// the admin routes there regardless.
 	const remoteClient = useRemoteClientContext().remote;
-	const [theme, setTheme] = useState<ThemeMode>(() => {
+	// "system" follows the OS setting via prefers-color-scheme. The old
+	// "exxperts.theme" key is read as a fallback so an explicit pre-appearance
+	// choice of light/dark survives the rename; users who never chose follow
+	// the system.
+	const [appearance, setAppearance] = useState<AppearancePreference>(() => {
 		try {
-			const saved = localStorage.getItem("exxperts.theme");
-			return saved === "light" || saved === "dark" ? saved : "dark";
+			const saved = localStorage.getItem("exxperts.appearance") ?? localStorage.getItem("exxperts.theme");
+			return saved === "light" || saved === "dark" || saved === "system" ? saved : "system";
 		} catch {
-			return "dark";
+			return "system";
 		}
 	});
+	const [systemDark, setSystemDark] = useState(() => (typeof window.matchMedia === "function" ? window.matchMedia("(prefers-color-scheme: dark)").matches : true));
+	useEffect(() => {
+		if (typeof window.matchMedia !== "function") return;
+		const query = window.matchMedia("(prefers-color-scheme: dark)");
+		const onChange = (event: MediaQueryListEvent) => setSystemDark(event.matches);
+		query.addEventListener("change", onChange);
+		return () => query.removeEventListener("change", onChange);
+	}, []);
+	const theme: ThemeMode = appearance === "system" ? (systemDark ? "dark" : "light") : appearance;
 	const [items, setItems] = useState<ChatItem[]>([]);
 	const [composerResetNonce, setComposerResetNonce] = useState(0);
 	// V6 iterate affordance: a one-shot composer prefill. Set together with a
@@ -3326,8 +3339,13 @@ export function App() {
 
 	useEffect(() => {
 		document.documentElement.dataset.theme = theme;
-		try { localStorage.setItem("exxperts.theme", theme); } catch {}
 	}, [theme]);
+	useEffect(() => {
+		try {
+			localStorage.setItem("exxperts.appearance", appearance);
+			localStorage.removeItem("exxperts.theme");
+		} catch {}
+	}, [appearance]);
 
 	useEffect(() => {
 		refreshAuthStatus(); // includes the model-status refresh
@@ -7330,13 +7348,13 @@ export function App() {
 				{gcReviewOpen && gcAssessment && <TaskStoreGcDialog assessment={gcAssessment} busy={gcBusy} onConfirm={() => void confirmTaskStoreGc()} onClose={() => setGcReviewOpen(false)} />}
 				{backgroundDoneToastView && <div className="launcher-toasts"><ToastStack toasts={[backgroundDoneToastView]} /></div>}
 				{whatsNew && <WhatsNewDialog version={whatsNew.version} entries={whatsNew.entries} onClose={dismissWhatsNew} />}
-				<Landing onOpenSettings={openSettings} onOpenDashboard={() => setView("dashboard")} onOpenMemory={() => setView("memory")} onOpenPersistentAgent={openPersistentAgent} onResumePersistentAgent={openPersistentAgentResume} onMaintainPersistentAgent={(target) => { if (!openMaintainChooser(target)) setPersistentResumeError(maintainBlockedReason(target.agentId) ?? "Maintain is not available for this room right now."); }} onCreatePersistentAgent={createPersistentAgentRoom} onArchiveRoom={archivePersistentAgentRoom} onPurgeRoom={purgePersistentAgentRoom} onMementoForget={(agentId) => { roomDraftsRef.current.delete(agentId); }} onRecordPreferredModel={recordRoomPreferredModel} modelStatus={modelStatus} persistentAgentStatuses={persistentAgentStatuses} persistentThread={persistentThread} persistentLive={!!persistentChat} persistentResumeError={persistentResumeError} onRefreshPersistentAgent={refreshPersistentAgentStatus} theme={theme} onToggleTheme={() => setTheme((t) => (t === "dark" ? "light" : "dark"))} aiProfileStatus={aiProfileStatus} onSelectAiProfile={selectAiProfile} standbyLockedModels={standbyLockedModels} backgroundReadyRooms={backgroundReadyRooms} purgingRooms={purgingRooms} />
+				<Landing onOpenSettings={openSettings} onOpenDashboard={() => setView("dashboard")} onOpenMemory={() => setView("memory")} onOpenPersistentAgent={openPersistentAgent} onResumePersistentAgent={openPersistentAgentResume} onMaintainPersistentAgent={(target) => { if (!openMaintainChooser(target)) setPersistentResumeError(maintainBlockedReason(target.agentId) ?? "Maintain is not available for this room right now."); }} onCreatePersistentAgent={createPersistentAgentRoom} onArchiveRoom={archivePersistentAgentRoom} onPurgeRoom={purgePersistentAgentRoom} onMementoForget={(agentId) => { roomDraftsRef.current.delete(agentId); }} onRecordPreferredModel={recordRoomPreferredModel} modelStatus={modelStatus} persistentAgentStatuses={persistentAgentStatuses} persistentThread={persistentThread} persistentLive={!!persistentChat} persistentResumeError={persistentResumeError} onRefreshPersistentAgent={refreshPersistentAgentStatus} theme={theme} appearance={appearance} onSetAppearance={setAppearance} aiProfileStatus={aiProfileStatus} onSelectAiProfile={selectAiProfile} standbyLockedModels={standbyLockedModels} backgroundReadyRooms={backgroundReadyRooms} purgingRooms={purgingRooms} />
 			</>
 		);
 	}
 
 	if (view === "memory") {
-		return withConnectionBanner(<MemoryShell onHome={goHome} onSettings={openSettings} onDashboard={() => setView("dashboard")} onMaintain={(target) => { if (openMaintainChooser(target, "memory")) setView("home"); }} maintainBlocked={maintainBlockedReason} theme={theme} onToggleTheme={() => setTheme((t) => (t === "dark" ? "light" : "dark"))} />);
+		return withConnectionBanner(<MemoryShell onHome={goHome} onSettings={openSettings} onDashboard={() => setView("dashboard")} onMaintain={(target) => { if (openMaintainChooser(target, "memory")) setView("home"); }} maintainBlocked={maintainBlockedReason} theme={theme} appearance={appearance} onSetAppearance={setAppearance} />);
 	}
 
 	if (view === "dashboard") {
@@ -7348,7 +7366,7 @@ export function App() {
 					onDashboard={() => {}}
 					onMemory={() => setView("memory")}
 					theme={theme}
-					onToggleTheme={() => setTheme((t) => (t === "dark" ? "light" : "dark"))}
+					appearance={appearance} onSetAppearance={setAppearance}
 					active="dashboard"
 				/>
 				<div className="landing dashboard-page">
@@ -7446,7 +7464,8 @@ export function App() {
 				<Sidebar
 					onHome={goHome}
 					theme={theme}
-					onToggleTheme={() => setTheme((t) => (t === "dark" ? "light" : "dark"))}
+					appearance={appearance}
+					onSetAppearance={setAppearance}
 					onSettings={openSettings}
 					assetsSlot={persistentChat ? <AssetsPanel rows={assetRows} selectedTaskId={selectedAssetTaskId} onSelect={openAssetRow} onStopRunning={() => dispatchTask({ type: "abort_requested" })} onRemove={(row) => void removeAssetRow(row)} onDeleteFile={(row, fileName) => requestFileDelete(row, fileName)} onRenameFile={(row, fileName, newName) => void renameFileRow(row, fileName, newName)} /> : undefined}
 				/>

--- a/apps/web-ui/src/components/Sidebar.tsx
+++ b/apps/web-ui/src/components/Sidebar.tsx
@@ -1,19 +1,20 @@
 import { SidebarToggleButton } from "../sidebar-collapse";
-import { RemoteOnPill, ConfigMenu, type ThemeMode } from "./product-shell";
+import { RemoteOnPill, ConfigMenu, type AppearancePreference, type ThemeMode } from "./product-shell";
 
 import type { ReactNode } from "react";
 
 interface Props {
 	onHome: () => void;
 	theme: ThemeMode;
-	onToggleTheme: () => void;
+	appearance: AppearancePreference;
+	onSetAppearance: (pref: AppearancePreference) => void;
 	/** Opens the Settings overlay over the room; the optional section targets it. */
 	onSettings: (section?: "remote") => void;
 	/** The Assets section (contract §2 rung 3) — the rail's first occupant below Home. */
 	assetsSlot?: ReactNode;
 }
 
-export function Sidebar({ theme, onToggleTheme, onSettings, onHome, assetsSlot }: Props) {
+export function Sidebar({ theme, appearance, onSetAppearance, onSettings, onHome, assetsSlot }: Props) {
 	return (
 		<aside className="sidebar">
 			<div className="sidebar-header">
@@ -31,7 +32,7 @@ export function Sidebar({ theme, onToggleTheme, onSettings, onHome, assetsSlot }
 			<div className="sidebar-footer">
 				<RemoteOnPill onSettings={onSettings} />
 				<div className="sidebar-footer-controls">
-					<ConfigMenu onSettings={onSettings} theme={theme} onToggleTheme={onToggleTheme} />
+					<ConfigMenu onSettings={onSettings} appearance={appearance} onSetAppearance={onSetAppearance} />
 					<SidebarToggleButton />
 				</div>
 			</div>

--- a/apps/web-ui/src/components/product-shell.tsx
+++ b/apps/web-ui/src/components/product-shell.tsx
@@ -7,6 +7,8 @@ import { requestUpdate, useUpdateNotice } from "../update-notice";
 import { Help } from "./Help";
 
 export type ThemeMode = "dark" | "light";
+/** What the user picked in the Appearance control; "system" resolves to a ThemeMode via prefers-color-scheme. */
+export type AppearancePreference = ThemeMode | "system";
 
 // Injected at build time from the root package.json "version" field (vite define).
 const APP_VERSION = __APP_VERSION__;
@@ -39,7 +41,7 @@ export type ProductSidebarActive = "home" | "ai-setup" | "remote" | "dashboard" 
  * same component, so the same settings are one click away wherever you are.
  * `onSettings` opens the Settings overlay; the optional section targets it.
  */
-export function ConfigMenu({ onSettings, theme, onToggleTheme }: { onSettings: (section?: "remote") => void; theme: ThemeMode; onToggleTheme: () => void }) {
+export function ConfigMenu({ onSettings, appearance, onSetAppearance }: { onSettings: (section?: "remote") => void; appearance: AppearancePreference; onSetAppearance: (pref: AppearancePreference) => void }) {
 	const [open, setOpen] = useState(false);
 	const [helpOpen, setHelpOpen] = useState(false);
 	const wrapRef = useRef<HTMLDivElement>(null);
@@ -71,10 +73,11 @@ export function ConfigMenu({ onSettings, theme, onToggleTheme }: { onSettings: (
 			{open && (
 				<div className="sidebar-config-menu" role="menu">
 					<div className="menu-row">
-						<span className="menu-row-label">Theme</span>
-						<div className="menu-theme-seg" role="group" aria-label="Theme">
-							<button className={theme === "dark" ? "on" : ""} aria-pressed={theme === "dark"} onClick={() => theme !== "dark" && onToggleTheme()}>Dark</button>
-							<button className={theme === "light" ? "on" : ""} aria-pressed={theme === "light"} onClick={() => theme !== "light" && onToggleTheme()}>Light</button>
+						<span className="menu-row-label">Appearance</span>
+						<div className="menu-appearance-seg" role="group" aria-label="Appearance">
+							<button className={appearance === "system" ? "on" : ""} aria-pressed={appearance === "system"} title="Follow this device's light or dark setting" onClick={() => onSetAppearance("system")}>System</button>
+							<button className={appearance === "light" ? "on" : ""} aria-pressed={appearance === "light"} onClick={() => onSetAppearance("light")}>Light</button>
+							<button className={appearance === "dark" ? "on" : ""} aria-pressed={appearance === "dark"} onClick={() => onSetAppearance("dark")}>Dark</button>
 						</div>
 					</div>
 					<button
@@ -168,7 +171,7 @@ export function RemoteOnPill({ onSettings }: { onSettings: (section?: "remote") 
 	);
 }
 
-export function ProductSidebar({ onHome, onSettings, onDashboard, onMemory, theme, onToggleTheme, active }: { onHome: () => void; onSettings: (section?: "remote") => void; onDashboard: () => void; onMemory?: () => void; theme: ThemeMode; onToggleTheme: () => void; active: ProductSidebarActive }) {
+export function ProductSidebar({ onHome, onSettings, onDashboard, onMemory, theme, appearance, onSetAppearance, active }: { onHome: () => void; onSettings: (section?: "remote") => void; onDashboard: () => void; onMemory?: () => void; theme: ThemeMode; appearance: AppearancePreference; onSetAppearance: (pref: AppearancePreference) => void; active: ProductSidebarActive }) {
 	return (
 		<aside className="product-sidebar">
 			<div className="product-sidebar-header">
@@ -195,7 +198,7 @@ export function ProductSidebar({ onHome, onSettings, onDashboard, onMemory, them
 			<div className="product-sidebar-footer">
 				<RemoteOnPill onSettings={onSettings} />
 				<div className="sidebar-footer-controls">
-					<ConfigMenu onSettings={onSettings} theme={theme} onToggleTheme={onToggleTheme} />
+					<ConfigMenu onSettings={onSettings} appearance={appearance} onSetAppearance={onSetAppearance} />
 					<SidebarToggleButton />
 				</div>
 			</div>

--- a/apps/web-ui/src/fixtures/FixtureGallery.tsx
+++ b/apps/web-ui/src/fixtures/FixtureGallery.tsx
@@ -20,7 +20,8 @@ function sidebarFixtureFor(active: ProductSidebarActive, theme: ThemeMode) {
 			onSettings={noop}
 			onDashboard={noop}
 			theme={theme}
-			onToggleTheme={noop}
+			appearance={theme}
+			onSetAppearance={noop}
 			active={active}
 		/>
 	);
@@ -190,7 +191,8 @@ function InRoomChatFixtureScreen({ fixture, theme }: { fixture: InRoomChatFixtur
 				<Sidebar
 					onHome={noop}
 					theme={theme}
-					onToggleTheme={noop}
+					appearance={theme}
+					onSetAppearance={noop}
 					onSettings={noop}
 				/>
 			}

--- a/apps/web-ui/src/styles.css
+++ b/apps/web-ui/src/styles.css
@@ -977,13 +977,13 @@ strong, b { font-weight: 700; }
 	margin-top: 4px;
 	padding-top: 10px;
 }
-.sidebar-config-menu .menu-theme-seg {
+.sidebar-config-menu .menu-appearance-seg {
 	display: inline-flex;
 	border: 1px solid var(--border);
 	border-radius: 6px;
 	overflow: hidden;
 }
-.sidebar-config-menu .menu-theme-seg button {
+.sidebar-config-menu .menu-appearance-seg button {
 	background: transparent;
 	border: 0;
 	color: var(--fg-soft);
@@ -991,12 +991,12 @@ strong, b { font-weight: 700; }
 	padding: 4px 10px;
 	cursor: pointer;
 }
-.sidebar-config-menu .menu-theme-seg button:hover,
-.sidebar-config-menu .menu-theme-seg button:focus-visible {
+.sidebar-config-menu .menu-appearance-seg button:hover,
+.sidebar-config-menu .menu-appearance-seg button:focus-visible {
 	color: var(--fg);
 	outline: none;
 }
-.sidebar-config-menu .menu-theme-seg button.on {
+.sidebar-config-menu .menu-appearance-seg button.on {
 	background: var(--fg);
 	color: var(--bg);
 }
@@ -1599,7 +1599,7 @@ strong, b { font-weight: 700; }
 	cursor: default;
 }
 .gateway-model-bulk-label { color: var(--muted); }
-/* Mirrors .menu-theme-seg at list scale. As two bare links the pair read as
+/* Mirrors .menu-appearance-seg at list scale. As two bare links the pair read as
    prose in the middle of a header, and "all on off" was one phrase nobody could
    see the seam in; bordered and joined, they read as the two buttons they are. */
 .gateway-model-bulk-seg {


### PR DESCRIPTION
Closes #42.

## What

The **Theme** toggle in the gear menu becomes a three-way **Appearance** control — **System / Light / Dark** — like the Claude desktop app. On System, the UI matches the OS setting and flips live the moment the OS does.

## How

- `prefers-color-scheme` via `window.matchMedia` with a `change` listener — one standard API that reflects the OS appearance in the browser and in the Electron shell on Windows, macOS, and Linux alike. No desktop-side code.
- **Preference vs. resolved theme:** the new `AppearancePreference` (`"system" | "light" | "dark"`) is what the user picks; the existing `ThemeMode` (`"dark" | "light"`) stays as the resolved theme, so every downstream consumer (`data-theme`, logo swap, charts) is untouched.
- **Migration:** the preference persists as `exxperts.appearance`. An explicit old light/dark choice under `exxperts.theme` is read once as the initial preference, then the old key is removed. Users who never touched the toggle now follow their system — the issue's ask.
- Naming follows the control: label and `aria-label` are "Appearance", the CSS class is `menu-appearance-seg`, props are `appearance`/`onSetAppearance`.
- On platforms that report no preference (bare Linux window managers), Chromium falls back to light — same behavior as every Chromium app.

## Verified

- `tsc --noEmit` clean, `vite build` green.
- Line-by-line diff audit: all 65 insertions / 41 deletions are appearance work; no unrelated changes.
